### PR TITLE
Dockerfile for Toradex Verdin iMX8M Mini ot3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+ Use Ubuntu 16.04 LTS as the basis for the Docker image.
+FROM ubuntu:16.04
+
+# Install all the Linux packages required for Yocto / Toradex BSP builds. Note that the packages python3,
+# tar, locales and cpio are not listed in the official Yocto / Toradex BSP documentation. The build, however, fails
+# without them. curl is used for brining in the repo tool. repo tool uses git, so thats being instaled here aswell.
+RUN apt-get update && apt-get -y install gawk wget git-core diffstat unzip texinfo gcc-multilib \
+     build-essential chrpath socat cpio python python3 python3-pip python3-pexpect \
+     xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
+     pylint3 xterm tar locales curl git
+# repo tool like python3.6
+RUN apt-get -y install software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get -y update && \
+    apt-get -y install python3.6
+
+# By default, Ubuntu uses dash as an alias for sh. Dash does not support the source command
+# needed for setting up the build environment in CMD. Use bash as an alias for sh.
+RUN rm /bin/sh && ln -s bash /bin/sh
+
+# Set the locale to en_US.UTF-8, because the Yocto build fails without any locale set.
+RUN locale-gen en_US.UTF-8 && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+ENV USER_NAME ot3
+ENV PROJECT ot3
+
+# The running container writes all the build artifacts to a host directory (outside the container).
+# The container can only write files to host directories, if it uses the same user ID and
+# group ID owning the host directories. The host_uid and group_uid are passed to the docker build
+# command with the --build-arg option. By default, they are both 1001. The docker image creates
+# a group with host_gid and a user with host_uid and adds the user to the group. The symbolic
+# name of the group and user is ot3.
+ARG host_uid=1001
+ARG host_gid=1001
+RUN groupadd -g $host_gid $USER_NAME && useradd -g $host_gid -m -s /bin/bash -u $host_uid $USER_NAME
+
+
+
+# Perform the Yocto build as user cuteradio (not as root).
+# NOTE: The USER command does not set the environment variable HOME.
+
+# By default, docker runs as root. However, Yocto builds should not be run as root, but as a 
+# normal user. Hence, we switch to the newly created user ot3.
+USER $USER_NAME
+
+RUN git config --global user.name "ot3" && \
+    git config --global user.email ot3@ot3.com
+
+# Create the directory structure for the Yocto build in the container. The lowest two directory
+# levels must be the same as on the host.
+ENV BUILD_INPUT_DIR /home/$USER_NAME/oe-core
+ENV BUILD_OUTPUT_DIR /home/$USER_NAME/oe-core/build
+RUN mkdir -p $BUILD_INPUT_DIR $BUILD_OUTPUT_DIR
+
+WORKDIR $BUILD_INPUT_DIR
+
+RUN mkdir bin
+ENV PATH="bin:${PATH}"
+RUN curl https://commondatastorage.googleapis.com/git-repo-downloads/repo > bin/repo && \
+    chmod a+x bin/repo
+RUN repo init -u https://git.toradex.com/toradex-manifest.git -b dunfell-5.x.y -m tdxref/default.xml
+RUN repo sync
+RUN . $BUILD_INPUT_DIR/export
+
+CMD echo "ACCEPT_FSL_EULA = \"1\"" >> $BUILD_OUTPUT_DIR/conf/local.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN groupadd -g $host_gid $USER_NAME && useradd -g $host_gid -m -s /bin/bash -u 
 
 
 
-# Perform the Yocto build as user cuteradio (not as root).
+# Perform the Yocto build as user ot3 (not as root).
+
 # NOTE: The USER command does not set the environment variable HOME.
 
 # By default, docker runs as root. However, Yocto builds should not be run as root, but as a 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,12 +68,12 @@ RUN repo init -u https://git.toradex.com/toradex-manifest.git -b dunfell-5.x.y -
 RUN repo sync
 
 ADD start.sh /home/ot3/start.sh
-ADD linux/linux-toradex_5.4-2.3.x.patch /home/ot3/oe-core/build/linux-toradex_5.4-2.3.x.patch
+ADD linux-toradex_5.4-2.3.x.patch /home/ot3/linux-toradex_5.4-2.3.x.patch
 USER root
 RUN chown -R $USER_NAME:$USER_NAME /home/ot3/start.sh
 RUN chmod a+x /home/ot3/start.sh
-RUN chown -R $USER_NAME:$USER_NAME /home/ot3/oe-core/build/linux-toradex_5.4-2.3.x.patch
-RUN chmod a+x /home/ot3/oe-core/build/linux-toradex_5.4-2.3.x.patch
+RUN chown -R $USER_NAME:$USER_NAME /home/ot3/linux-toradex_5.4-2.3.x.patch
+RUN chmod a+x /home/ot3/linux-toradex_5.4-2.3.x.patch
 
 USER $USER_NAME
 CMD /home/ot3/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
- Use Ubuntu 16.04 LTS as the basis for the Docker image.
+# In any directory on the docker host, perform the following actions:
+#   * Copy this Dockerfile in the directory.
+#   * Create input and output directories: mkdir -p oe-core oe-core/build
+#   * Build the Docker image with the following command:
+#     docker build --no-cache --build-arg "host_uid=$(id -u)" --build-arg "host_gid=$(id -g)" \
+#         --tag "ot3-image:latest" .
+#   * Run the Docker image, which in turn runs the Yocto and which produces the Linux rootfs,
+#     with the following command:
+#     docker run -it --rm -v $PWD/oe-core/build:/home/ot3/oe-core/build ot3-image:latest
+# Use Ubuntu 16.04 LTS as the basis for the Docker image.
 FROM ubuntu:16.04
 
 # Install all the Linux packages required for Yocto / Toradex BSP builds. Note that the packages python3,

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,12 @@ RUN repo init -u https://git.toradex.com/toradex-manifest.git -b dunfell-5.x.y -
 RUN repo sync
 
 ADD start.sh /home/ot3/start.sh
+ADD linux/linux-toradex_5.4-2.3.x.patch /home/ot3/oe-core/build/linux-toradex_5.4-2.3.x.patch
 USER root
 RUN chown -R $USER_NAME:$USER_NAME /home/ot3/start.sh
 RUN chmod a+x /home/ot3/start.sh
+RUN chown -R $USER_NAME:$USER_NAME /home/ot3/oe-core/build/linux-toradex_5.4-2.3.x.patch
+RUN chmod a+x /home/ot3/oe-core/build/linux-toradex_5.4-2.3.x.patch
+
 USER $USER_NAME
 CMD /home/ot3/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 # Use Ubuntu 16.04 LTS as the basis for the Docker image.
-FROM ubuntu:16.04
+
+FROM ubuntu:20.04
+
+# Set timezone:
+RUN ln -snf /usr/share/zoneinfo/$CONTAINER_TIMEZONE /etc/localtime && echo $CONTAINER_TIMEZONE > /etc/timezone
 
 # Install all the Linux packages required for Yocto / Toradex BSP builds. Note that the packages python3,
 # tar, locales and cpio are not listed in the official Yocto / Toradex BSP documentation. The build, however, fails
 # without them. curl is used for brining in the repo tool. repo tool uses git, so thats being instaled here aswell.
+
 RUN apt-get update && apt-get -y install gawk wget git-core diffstat unzip texinfo gcc-multilib \
      build-essential chrpath socat cpio python python3 python3-pip python3-pexpect \
      xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
@@ -38,7 +43,6 @@ RUN groupadd -g $host_gid $USER_NAME && useradd -g $host_gid -m -s /bin/bash -u 
 
 
 # Perform the Yocto build as user ot3 (not as root).
-
 # NOTE: The USER command does not set the environment variable HOME.
 
 # By default, docker runs as root. However, Yocto builds should not be run as root, but as a 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,8 @@ RUN groupadd -g $host_gid $USER_NAME && useradd -g $host_gid -m -s /bin/bash -u 
 # normal user. Hence, we switch to the newly created user ot3.
 USER $USER_NAME
 
-RUN git config --global user.name "ot3" && \
-    git config --global user.email ot3@ot3.com
+RUN git config --global user.name "Opentrons" && \
+    git config --global user.email engineering@opentrons.com
 
 # Create the directory structure for the Yocto build in the container. The lowest two directory
 # levels must be the same as on the host.

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,3 +66,6 @@ RUN repo sync
 RUN . $BUILD_INPUT_DIR/export
 
 CMD echo "ACCEPT_FSL_EULA = \"1\"" >> $BUILD_OUTPUT_DIR/conf/local.conf
+CMD sed -i '/#MACHINE ?= "verdin-imx8mm"/c\MACHINE ?= "verdin-imx8mm"' $BUILD_OUTPUT_DIR/conf/local.conf
+CMD sed -i '/MACHINE ?= "colibri-imx6"/c\#MACHINE ?= "colbri-imx6"' $BUILD_OUTPUT_DIR_conf/local.conf
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:16.04
 
 # Install all the Linux packages required for Yocto / Toradex BSP builds. Note that the packages python3,
 # tar, locales and cpio are not listed in the official Yocto / Toradex BSP documentation. The build, however, fails
-# without them. curl is used for brining in the repo tool. repo tool uses git, so thats being instaled here aswell.
+# without them. curl is used for brining in the repo tool. repo tool uses git, so thats being installed here as well.
 RUN apt-get update && apt-get -y install gawk wget git-core diffstat unzip texinfo gcc-multilib \
      build-essential chrpath socat cpio python python3 python3-pip python3-pexpect \
      xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
@@ -38,7 +38,7 @@ RUN groupadd -g $host_gid $USER_NAME && useradd -g $host_gid -m -s /bin/bash -u 
 
 
 
-# Perform the Yocto build as user cuteradio (not as root).
+# Perform the Yocto build as user ot3  (not as root).
 # NOTE: The USER command does not set the environment variable HOME.
 
 # By default, docker runs as root. However, Yocto builds should not be run as root, but as a 
@@ -56,6 +56,7 @@ RUN mkdir -p $BUILD_INPUT_DIR $BUILD_OUTPUT_DIR
 
 WORKDIR $BUILD_INPUT_DIR
 
+#bring in repo tool
 RUN mkdir bin
 ENV PATH="bin:${PATH}"
 RUN curl https://commondatastorage.googleapis.com/git-repo-downloads/repo > bin/repo && \

--- a/linux-toradex_5.4-2.3.x.patch
+++ b/linux-toradex_5.4-2.3.x.patch
@@ -1,43 +1,8 @@
---- oe-core-faulty/layers/meta-toradex-nxp/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bb	2021-06-11 13:15:27.526030783 +0000
-+++ oe-core/layers/meta-toradex-nxp/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bb	2021-06-10 14:43:38.659486270 +0000
-@@ -7,14 +7,14 @@
- LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
- 
- SRC_URI = " \
--    git://git.toradex.com/linux-toradex.git;protocol=https;branch=${SRCBRANCH};name=machine \
-+    git://git.toradex.com/linux-toradex.git;protocol=http;branch=${SRCBRANCH};name=machine \
- "
- 
- # Load USB functions configurable through configfs (CONFIG_USB_CONFIGFS)
- KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains('COMBINED_FEATURES', 'usbgadget', ' libcomposite', '',d)}"
- 
- inherit toradex-kernel-localversion
--LINUX_VERSION = "5.4.115"
-+LINUX_VERSION = "5.4.91"
- # skip, as with use-head-next LINUX_VERSION might be set wrongly
- KERNEL_VERSION_SANITY_SKIP_use-head-next = "1"
- 
-@@ -22,7 +22,7 @@
- LOCALVERSION = "-${TDX_VERSION}"
- 
- SRCBRANCH = "toradex_5.4-2.3.x-imx"
--SRCREV_machine = "64dbf17bb33e10d844b01fd7294104cd4f1b8c5b"
-+SRCREV_machine = "2dd6306225361e47a9ef40f6a81a5487920a09ab"
- SRCREV_machine_use-head-next = "${AUTOREV}"
- 
- DEPENDS += "lzop-native bc-native"
-@@ -43,7 +43,7 @@
- # both possible storage locations.
- MIRRORS_append_preempt-rt = "${KERNELORG_MIRROR}/linux/kernel/projects/rt/5.4/older/ ${KERNELORG_MIRROR}/linux/kernel/projects/rt/5.4/"
- SRC_URI_append_preempt-rt = " \
--    ${KERNELORG_MIRROR}/linux/kernel/projects/rt/5.4/older/patch-5.4.115-rt57.patch.xz;name=rt-patch \
-+    ${KERNELORG_MIRROR}/linux/kernel/projects/rt/5.4/older/patch-5.4.91-rt50.patch.xz;name=rt-patch \
-     file://preempt-rt.scc \
-     file://preempt-rt-less-latency.scc \
- "
-@@ -53,4 +53,4 @@
- #    file://0002-ddr-perf-prevent-BUG-with-rt-patch.patch \
- #
- 
--SRC_URI[rt-patch.sha256sum] = "133c73625664f72702e85fc037e9a4169e16c9b45444af1c9416157c44ec07f6"
-+SRC_URI[rt-patch.sha256sum] = "3152fac82ee4357f89035736de707545b36b1816536d17cc76bd830b488a2923"
+10c10
+<     git://git.toradex.com/linux-toradex.git;protocol=https;branch=${SRCBRANCH};name=machine \
+---
+>     git://git.toradex.com/linux-toradex.git;protocol=http;branch=${SRCBRANCH};name=machine \
+25c25
+< SRCREV_machine = "64dbf17bb33e10d844b01fd7294104cd4f1b8c5b"
+---
+> SRCREV_machine = "2dd6306225361e47a9ef40f6a81a5487920a09ab"

--- a/linux-toradex_5.4-2.3.x.patch
+++ b/linux-toradex_5.4-2.3.x.patch
@@ -1,0 +1,43 @@
+--- oe-core-faulty/layers/meta-toradex-nxp/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bb	2021-06-11 13:15:27.526030783 +0000
++++ oe-core/layers/meta-toradex-nxp/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bb	2021-06-10 14:43:38.659486270 +0000
+@@ -7,14 +7,14 @@
+ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+ 
+ SRC_URI = " \
+-    git://git.toradex.com/linux-toradex.git;protocol=https;branch=${SRCBRANCH};name=machine \
++    git://git.toradex.com/linux-toradex.git;protocol=http;branch=${SRCBRANCH};name=machine \
+ "
+ 
+ # Load USB functions configurable through configfs (CONFIG_USB_CONFIGFS)
+ KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains('COMBINED_FEATURES', 'usbgadget', ' libcomposite', '',d)}"
+ 
+ inherit toradex-kernel-localversion
+-LINUX_VERSION = "5.4.115"
++LINUX_VERSION = "5.4.91"
+ # skip, as with use-head-next LINUX_VERSION might be set wrongly
+ KERNEL_VERSION_SANITY_SKIP_use-head-next = "1"
+ 
+@@ -22,7 +22,7 @@
+ LOCALVERSION = "-${TDX_VERSION}"
+ 
+ SRCBRANCH = "toradex_5.4-2.3.x-imx"
+-SRCREV_machine = "64dbf17bb33e10d844b01fd7294104cd4f1b8c5b"
++SRCREV_machine = "2dd6306225361e47a9ef40f6a81a5487920a09ab"
+ SRCREV_machine_use-head-next = "${AUTOREV}"
+ 
+ DEPENDS += "lzop-native bc-native"
+@@ -43,7 +43,7 @@
+ # both possible storage locations.
+ MIRRORS_append_preempt-rt = "${KERNELORG_MIRROR}/linux/kernel/projects/rt/5.4/older/ ${KERNELORG_MIRROR}/linux/kernel/projects/rt/5.4/"
+ SRC_URI_append_preempt-rt = " \
+-    ${KERNELORG_MIRROR}/linux/kernel/projects/rt/5.4/older/patch-5.4.115-rt57.patch.xz;name=rt-patch \
++    ${KERNELORG_MIRROR}/linux/kernel/projects/rt/5.4/older/patch-5.4.91-rt50.patch.xz;name=rt-patch \
+     file://preempt-rt.scc \
+     file://preempt-rt-less-latency.scc \
+ "
+@@ -53,4 +53,4 @@
+ #    file://0002-ddr-perf-prevent-BUG-with-rt-patch.patch \
+ #
+ 
+-SRC_URI[rt-patch.sha256sum] = "133c73625664f72702e85fc037e9a4169e16c9b45444af1c9416157c44ec07f6"
++SRC_URI[rt-patch.sha256sum] = "3152fac82ee4357f89035736de707545b36b1816536d17cc76bd830b488a2923"

--- a/ot3Image.sh
+++ b/ot3Image.sh
@@ -27,7 +27,6 @@ echo $branch
 curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/Dockerfile" > Dockerfile
 curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/start.sh" > start.sh
 curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/linux-toradex_5.4-2.3.x.patch" > linux-toradex_5.4-2.3.x.patch
-patch /home/ot3/oe-core/layers/meta-toradex-nxp/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bb /home/ot3/oe-core/build/linux-toradex_5.4-2.3.x.patch
 
 docker build --no-cache --build-arg "host_uid=1000"   --build-arg "host_gid=1000" --tag "ot3-image:latest" .
 docker run -it --rm -v $PWD/oe-core/build:/home/ot3/oe-core/build/deploy ot3-image:latest

--- a/ot3Image.sh
+++ b/ot3Image.sh
@@ -17,10 +17,10 @@ while getopts ":b:" opt; do
 done
 shift $((OPTIND - 1))
 
-mkdir docker-test
-cd docker-test
+mkdir -p docker
+cd docker
 mkdir -p oe-core/build
-#change branch to main eventually, or pass as cmdline args
+
 curl 'https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/Dockerfile' > DockerFile
 curl 'https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/start.sh' > start.sh
 docker run -it --rm -v $PWD/oe-core/build:/home/ot3/oe-core/build/deploy ot3-image:latest

--- a/ot3Image.sh
+++ b/ot3Image.sh
@@ -4,6 +4,7 @@ while getopts ":b:" opt; do
   case $opt in
     b)
       branch=$OPTARG >&2
+      echo $OPTARG
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -17,14 +18,13 @@ while getopts ":b:" opt; do
 done
 shift $((OPTIND - 1))
 
+
 mkdir -p docker
 cd docker
 mkdir -p oe-core/build
 
-curl 'https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/Dockerfile' > DockerFile
-curl 'https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/start.sh' > start.sh
+echo $branch
+curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/Dockerfile" > Dockerfile
+curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/start.sh" > start.sh
 
-docker build --no-cache --build-arg "host_uid=$(id -u)"   --build-arg "host_gid=$(id -g)" --tag "ot3-image:latest" .
-
-docker run -it --rm -v $PWD/oe-core/build:/home/ot3/oe-core/build/deploy ot3-image:latest
 

--- a/ot3Image.sh
+++ b/ot3Image.sh
@@ -28,6 +28,7 @@ curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/Docke
 curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/start.sh" > start.sh
 curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/linux-toradex_5.4-2.3.x.patch" > linux-toradex_5.4-2.3.x.patch
 
-docker build --no-cache --build-arg "host_uid=1000"   --build-arg "host_gid=1000" --tag "ot3-image:latest" .
+
+docker build --build-arg "host_uid=1000"   --build-arg "host_gid=1000" --tag "ot3-image:latest" .
 docker run -it --rm -v $PWD/oe-core/build:/home/ot3/oe-core/build/deploy ot3-image:latest
 

--- a/ot3Image.sh
+++ b/ot3Image.sh
@@ -26,6 +26,9 @@ mkdir -p oe-core/build
 echo $branch
 curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/Dockerfile" > Dockerfile
 curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/start.sh" > start.sh
+curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/linux-toradex_5.4-2.3.x.patch" > linux-toradex_5.4-2.3.x.patch
+patch /home/ot3/oe-core/layers/meta-toradex-nxp/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bb /home/ot3/oe-core/build/linux-toradex_5.4-2.3.x.patch
+
 docker build --no-cache --build-arg "host_uid=1000"   --build-arg "host_gid=1000" --tag "ot3-image:latest" .
 docker run -it --rm -v $PWD/oe-core/build:/home/ot3/oe-core/build/deploy ot3-image:latest
 

--- a/ot3Image.sh
+++ b/ot3Image.sh
@@ -23,5 +23,8 @@ mkdir -p oe-core/build
 
 curl 'https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/Dockerfile' > DockerFile
 curl 'https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/start.sh' > start.sh
+
+docker build --no-cache --build-arg "host_uid=$(id -u)"   --build-arg "host_gid=$(id -g)" --tag "ot3-image:latest" .
+
 docker run -it --rm -v $PWD/oe-core/build:/home/ot3/oe-core/build/deploy ot3-image:latest
 

--- a/ot3Image.sh
+++ b/ot3Image.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+mkdir docker-test
+cd docker-test
+mkdir -p oe-core/build
+#change branch to main eventually, or pass as cmdline args
+curl 'https://raw.githubusercontent.com/Opentrons/meta-opentrons/docker-ot3/Dockerfile' > DockerFile
+curl 'https://raw.githubusercontent.com/Opentrons/meta-opentrons/docker-ot3/start.sh' > start.sh
+docker run -it --rm -v $PWD/oe-core/build:/home/ot3/oe-core/build/deploy ot3-image:latest
+

--- a/ot3Image.sh
+++ b/ot3Image.sh
@@ -26,5 +26,6 @@ mkdir -p oe-core/build
 echo $branch
 curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/Dockerfile" > Dockerfile
 curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/start.sh" > start.sh
-
+docker build --no-cache --build-arg "host_uid=$(id -u)"   --build-arg "host_gid=$(id -g)" --tag "ot3-image:latest" .
+docker run -it --rm -v $PWD/oe-core/build:/home/ot3/oe-core/build/deploy ot3-image:latest
 

--- a/ot3Image.sh
+++ b/ot3Image.sh
@@ -1,9 +1,27 @@
-#! /bin/sh
+#! /bin/bash
+branch=  
+while getopts ":b:" opt; do
+  case $opt in
+    b)
+      branch=$OPTARG >&2
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
 mkdir docker-test
 cd docker-test
 mkdir -p oe-core/build
 #change branch to main eventually, or pass as cmdline args
-curl 'https://raw.githubusercontent.com/Opentrons/meta-opentrons/docker-ot3/Dockerfile' > DockerFile
-curl 'https://raw.githubusercontent.com/Opentrons/meta-opentrons/docker-ot3/start.sh' > start.sh
+curl 'https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/Dockerfile' > DockerFile
+curl 'https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/start.sh' > start.sh
 docker run -it --rm -v $PWD/oe-core/build:/home/ot3/oe-core/build/deploy ot3-image:latest
 

--- a/ot3Image.sh
+++ b/ot3Image.sh
@@ -26,6 +26,6 @@ mkdir -p oe-core/build
 echo $branch
 curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/Dockerfile" > Dockerfile
 curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/start.sh" > start.sh
-docker build --no-cache --build-arg "host_uid=$(id -u)"   --build-arg "host_gid=$(id -g)" --tag "ot3-image:latest" .
+docker build --no-cache --build-arg "host_uid=1000"   --build-arg "host_gid=1000" --tag "ot3-image:latest" .
 docker run -it --rm -v $PWD/oe-core/build:/home/ot3/oe-core/build/deploy ot3-image:latest
 

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,10 @@
 rm -f /home/ot3/oe-core/build/tmp-glibc
 source /home/ot3/oe-core/export
 cd /home/ot3/oe-core/build
+echo 'INHERIT += "toradex-mirrors"' >> /home/ot3/oe-core/build/conf/local.conf
+echo 'MACHINEOVERRIDES =. "use-head-next:"' >> /home/ot3/oe-core/build/conf/local.conf
 echo 'ACCEPT_FSL_EULA = "1"' >> /home/ot3/oe-core/build/conf/local.conf
 sed -i '/#MACHINE ?= "verdin-imx8mm"/c\MACHINE ?= "verdin-imx8mm"' /home/ot3/oe-core/build/conf/local.conf
 sed -i '/MACHINE ?= "colibri-imx6"/c\#MACHINE ?= "colbri-imx6"' /home/ot3/oe-core/build/conf/local.conf
+bitbake -c cleanall tdx-reference-minimal-image
 bitbake tdx-reference-minimal-image

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 rm -f /home/ot3/oe-core/build/tmp-glibc
-rm-rf /home/ot3/oe-core/build/deploy
+rm -rf /home/ot3/oe-core/build/deploy
 source /home/ot3/oe-core/export
 #apply patch 
 

--- a/start.sh
+++ b/start.sh
@@ -10,6 +10,6 @@ echo 'ACCEPT_FSL_EULA = "1"' >> /home/ot3/oe-core/build/conf/local.conf
 sed -i '/#MACHINE ?= "verdin-imx8mm"/c\MACHINE ?= "verdin-imx8mm"' /home/ot3/oe-core/build/conf/local.conf
 sed -i '/MACHINE ?= "colibri-imx6"/c\#MACHINE ?= "colbri-imx6"' /home/ot3/oe-core/build/conf/local.conf
 
-patch /home/ot3/oe-core/layers/meta-toradex-nxp/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bb /home/ot3/oe-core/build/linux-toradex_5.4-2.3.x.patch
+patch /home/ot3/oe-core/layers/meta-toradex-nxp/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bb /home/ot3/linux-toradex_5.4-2.3.x.patch
 bitbake -c cleanall tdx-reference-minimal-image
 bitbake tdx-reference-minimal-image

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,5 @@
 #! /bin/sh
+rm -f /home/ot3/oe-core/build/tmp
 rm -f /home/ot3/oe-core/build/tmp-glibc
 rm -rf /home/ot3/oe-core/build/deploy
 source /home/ot3/oe-core/export

--- a/start.sh
+++ b/start.sh
@@ -4,6 +4,7 @@ rm -rf /home/ot3/oe-core/build/deploy
 source /home/ot3/oe-core/export
 cd /home/ot3/oe-core/build
 echo 'ACCEPT_FSL_EULA = "1"' >> /home/ot3/oe-core/build/conf/local.conf
+echo 'MACHINEOVERRIDES =. “use-head-next:”' >> /home/ot3/oe-core/build/conf/local.conf
 sed -i '/#MACHINE ?= "verdin-imx8mm"/c\MACHINE ?= "verdin-imx8mm"' /home/ot3/oe-core/build/conf/local.conf
 sed -i '/MACHINE ?= "colibri-imx6"/c\#MACHINE ?= "colbri-imx6"' /home/ot3/oe-core/build/conf/local.conf
 bitbake tdx-reference-minimal-image

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
 #! /bin/sh
 rm -f /home/ot3/oe-core/build/tmp-glibc
+rm-rf /home/ot3/oe-core/build/deploy
 source /home/ot3/oe-core/export
 #apply patch 
 

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,5 @@
 #! /bin/sh
 rm -f /home/ot3/oe-core/build/tmp-glibc
-rm -rf /home/ot3/oe-core/build/deploy
 source /home/ot3/oe-core/export
 cd /home/ot3/oe-core/build
 echo 'ACCEPT_FSL_EULA = "1"' >> /home/ot3/oe-core/build/conf/local.conf

--- a/start.sh
+++ b/start.sh
@@ -1,11 +1,16 @@
 #! /bin/sh
 rm -f /home/ot3/oe-core/build/tmp-glibc
 source /home/ot3/oe-core/export
+#apply patch 
+
 cd /home/ot3/oe-core/build
 echo 'INHERIT += "toradex-mirrors"' >> /home/ot3/oe-core/build/conf/local.conf
 echo 'MACHINEOVERRIDES =. "use-head-next:"' >> /home/ot3/oe-core/build/conf/local.conf
 echo 'ACCEPT_FSL_EULA = "1"' >> /home/ot3/oe-core/build/conf/local.conf
 sed -i '/#MACHINE ?= "verdin-imx8mm"/c\MACHINE ?= "verdin-imx8mm"' /home/ot3/oe-core/build/conf/local.conf
 sed -i '/MACHINE ?= "colibri-imx6"/c\#MACHINE ?= "colbri-imx6"' /home/ot3/oe-core/build/conf/local.conf
+
+curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/linux-toradex_5.4-2.3.x.patch" > linux-toradex_5.4-2.3.x.patch
+patch ../layers/meta-toradex-nxp/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bb linux-toradex_5.4-2.3.x.patch
 bitbake -c cleanall tdx-reference-minimal-image
 bitbake tdx-reference-minimal-image

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-rm -f /home/ot3/oe-core/build/tmp
+rm -rf /home/ot3/oe-core/build/tmp
 rm -f /home/ot3/oe-core/build/tmp-glibc
 rm -rf /home/ot3/oe-core/build/deploy
 source /home/ot3/oe-core/export

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+rm -f /home/ot3/oe-core/build/tmp-glibc
+rm -rf /home/ot3/oe-core/build/deploy
+source /home/ot3/oe-core/export
+cd /home/ot3/oe-core/build
+echo 'ACCEPT_FSL_EULA = "1"' >> /home/ot3/oe-core/build/conf/local.conf
+sed -i '/#MACHINE ?= "verdin-imx8mm"/c\MACHINE ?= "verdin-imx8mm"' /home/ot3/oe-core/build/conf/local.conf
+sed -i '/MACHINE ?= "colibri-imx6"/c\#MACHINE ?= "colbri-imx6"' /home/ot3/oe-core/build/conf/local.conf
+bitbake tdx-reference-minimal-image

--- a/start.sh
+++ b/start.sh
@@ -7,5 +7,5 @@ cd /home/ot3/oe-core/build
 echo 'ACCEPT_FSL_EULA = "1"' >> /home/ot3/oe-core/build/conf/local.conf
 sed -i '/#MACHINE ?= "verdin-imx8mm"/c\MACHINE ?= "verdin-imx8mm"' /home/ot3/oe-core/build/conf/local.conf
 sed -i '/MACHINE ?= "colibri-imx6"/c\#MACHINE ?= "colbri-imx6"' /home/ot3/oe-core/build/conf/local.conf
-sed -i '/INHERIT += "toradex-mirrors"/c\#INHERIT += "toradex-mirrors"' /homt/ot3/oe-core/build/conf/local.conf
+sed -i '/INHERIT += "toradex-mirrors"/c\#INHERIT += "toradex-mirrors"' /home/ot3/oe-core/build/conf/local.conf
 bitbake tdx-reference-minimal-image

--- a/start.sh
+++ b/start.sh
@@ -4,7 +4,6 @@ rm -rf /home/ot3/oe-core/build/deploy
 source /home/ot3/oe-core/export
 cd /home/ot3/oe-core/build
 echo 'ACCEPT_FSL_EULA = "1"' >> /home/ot3/oe-core/build/conf/local.conf
-echo 'MACHINEOVERRIDES =. “use-head-next:”' >> /home/ot3/oe-core/build/conf/local.conf
 sed -i '/#MACHINE ?= "verdin-imx8mm"/c\MACHINE ?= "verdin-imx8mm"' /home/ot3/oe-core/build/conf/local.conf
 sed -i '/MACHINE ?= "colibri-imx6"/c\#MACHINE ?= "colbri-imx6"' /home/ot3/oe-core/build/conf/local.conf
 bitbake tdx-reference-minimal-image

--- a/start.sh
+++ b/start.sh
@@ -10,7 +10,7 @@ echo 'ACCEPT_FSL_EULA = "1"' >> /home/ot3/oe-core/build/conf/local.conf
 sed -i '/#MACHINE ?= "verdin-imx8mm"/c\MACHINE ?= "verdin-imx8mm"' /home/ot3/oe-core/build/conf/local.conf
 sed -i '/MACHINE ?= "colibri-imx6"/c\#MACHINE ?= "colbri-imx6"' /home/ot3/oe-core/build/conf/local.conf
 
-curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/linux-toradex_5.4-2.3.x.patch" > linux-toradex_5.4-2.3.x.patch
-patch ../layers/meta-toradex-nxp/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bb linux-toradex_5.4-2.3.x.patch
+curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/linux-toradex_5.4-2.3.x.patch" > /home/ot3/oe-core/build/linux-toradex_5.4-2.3.x.patch
+patch /home/ot3/oe-core/layers/meta-toradex-nxp/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bb /home/ot3/oe-core/build/linux-toradex_5.4-2.3.x.patch
 bitbake -c cleanall tdx-reference-minimal-image
 bitbake tdx-reference-minimal-image

--- a/start.sh
+++ b/start.sh
@@ -10,7 +10,6 @@ echo 'ACCEPT_FSL_EULA = "1"' >> /home/ot3/oe-core/build/conf/local.conf
 sed -i '/#MACHINE ?= "verdin-imx8mm"/c\MACHINE ?= "verdin-imx8mm"' /home/ot3/oe-core/build/conf/local.conf
 sed -i '/MACHINE ?= "colibri-imx6"/c\#MACHINE ?= "colbri-imx6"' /home/ot3/oe-core/build/conf/local.conf
 
-curl "https://raw.githubusercontent.com/Opentrons/meta-opentrons/${branch}/linux-toradex_5.4-2.3.x.patch" > /home/ot3/oe-core/build/linux-toradex_5.4-2.3.x.patch
 patch /home/ot3/oe-core/layers/meta-toradex-nxp/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bb /home/ot3/oe-core/build/linux-toradex_5.4-2.3.x.patch
 bitbake -c cleanall tdx-reference-minimal-image
 bitbake tdx-reference-minimal-image

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,4 @@
 #! /bin/sh
-rm -rf /home/ot3/oe-core/build/tmp
 rm -f /home/ot3/oe-core/build/tmp-glibc
 rm -rf /home/ot3/oe-core/build/deploy
 source /home/ot3/oe-core/export
@@ -7,5 +6,4 @@ cd /home/ot3/oe-core/build
 echo 'ACCEPT_FSL_EULA = "1"' >> /home/ot3/oe-core/build/conf/local.conf
 sed -i '/#MACHINE ?= "verdin-imx8mm"/c\MACHINE ?= "verdin-imx8mm"' /home/ot3/oe-core/build/conf/local.conf
 sed -i '/MACHINE ?= "colibri-imx6"/c\#MACHINE ?= "colbri-imx6"' /home/ot3/oe-core/build/conf/local.conf
-sed -i '/INHERIT += "toradex-mirrors"/c\#INHERIT += "toradex-mirrors"' /home/ot3/oe-core/build/conf/local.conf
 bitbake tdx-reference-minimal-image

--- a/start.sh
+++ b/start.sh
@@ -7,4 +7,5 @@ cd /home/ot3/oe-core/build
 echo 'ACCEPT_FSL_EULA = "1"' >> /home/ot3/oe-core/build/conf/local.conf
 sed -i '/#MACHINE ?= "verdin-imx8mm"/c\MACHINE ?= "verdin-imx8mm"' /home/ot3/oe-core/build/conf/local.conf
 sed -i '/MACHINE ?= "colibri-imx6"/c\#MACHINE ?= "colbri-imx6"' /home/ot3/oe-core/build/conf/local.conf
+sed -i '/INHERIT += "toradex-mirrors"/c\#INHERIT += "toradex-mirrors"' /homt/ot3/oe-core/build/conf/local.conf
 bitbake tdx-reference-minimal-image


### PR DESCRIPTION
Docker image for ot3
**Few reasons behind this Docker image:**

1. Facilitate ot3 Linux image building 
2. provide a means of having all necessary/required data readily available
3. Dev team doesn't have to worry about searching for Yocto sources, Ubuntu Images, and installation information.

ot3Image.sh script can be to run on a Ubuntu machine/EC2 instance (with Docker installed) to generate a Toradex verdin-imx8mm image using this docker image.

Note: To avoid running docker commands as root - 
sudo usermod -a -G docker "$(whoami)"
