### PR TITLE
systemd opentrons-robot-server.service

### DIFF
--- a/recipes-robot/systemd/files/opentrons-robot-server.service
+++ b/recipes-robot/systemd/files/opentrons-robot-server.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Opentrons Robot HTTP Server
+Requires=nginx.service
+After=nginx.service
+After=opentrons-status-leds.service
+
+[Service]
+Type=notify
+ExecStart=uvicorn robot_server:app --uds /run/aiohttp.sock --ws wsproto
+# Stop the button blinking
+ExecStartPost=systemctl stop opentrons-gpio-setup.service
+Environment=OT_SMOOTHIE_ID=AMA RUNNING_ON_PI=true
+Restart=on-failure
+TimeoutStartSec=3min
+
+[Install]
+WantedBy=opentrons.target

--- a/recipes-robot/systemd/files/opentrons.target
+++ b/recipes-robot/systemd/files/opentrons.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=Opentrons System
+Requires=multi-user.target
+Conflicts=emergency.target

--- a/recipes-robot/systemd/robotserversystemd_1.00.bb
+++ b/recipes-robot/systemd/robotserversystemd_1.00.bb
@@ -8,7 +8,7 @@ FILES_${PN} += "${systemd_system_unitdir}/opentrons-robot-server.service"
 FILES_${PN} += "${systemd_system_unitdir}/opentrons.target"
 FILES_${PN} += "${systemd_system_unitdir}/opentrons.targets.wants"
 
-RDEPENDS_${PN} = "nginx"
+RDEPENDS_${PN} = "nginx python3-uvicorn"
 do_install_append() {
   install -d ${D}${systemd_system_unitdir}
   install -m 0644 ${WORKDIR}/opentrons-robot-server.service ${D}${systemd_system_unitdir}

--- a/recipes-robot/systemd/robotserversystemd_1.00.bb
+++ b/recipes-robot/systemd/robotserversystemd_1.00.bb
@@ -1,0 +1,17 @@
+inherit systemd
+
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE_${PN} = "opentrons-robot-server.service"
+LICENSE="CLOSED"
+SRC_URI_append = "  file://opentrons-robot-server.service file://opentrons.target file://opentrons.targets.wants/ "
+FILES_${PN} += "${systemd_system_unitdir}/opentrons-robot-server.service"
+FILES_${PN} += "${systemd_system_unitdir}/opentrons.target"
+FILES_${PN} += "${systemd_system_unitdir}/opentrons.targets.wants"
+
+RDEPENDS_${PN} = "nginx"
+do_install_append() {
+  install -d ${D}${systemd_system_unitdir}
+  install -m 0644 ${WORKDIR}/opentrons-robot-server.service ${D}${systemd_system_unitdir}
+  install -m 0644 ${WORKDIR}/opentrons.target ${D}${systemd_system_unitdir}
+  cp -r ${WORKDIR}/opentrons.targets.wants ${D}${systemd_system_unitdir}/opentrons.targets.wants
+}


### PR DESCRIPTION
local.conf also requires changes to setup systemd as runtime init manager. Those changes would go under oe-core repo.