### PR TITLE
chore(build): Enable builds for pull requests

### DIFF
--- a/.github/workflows/enable-upstream-builds.yaml
+++ b/.github/workflows/enable-upstream-builds.yaml
@@ -1,0 +1,83 @@
+# Ensures that when a pull request occurs, a branch matching the name of
+# the branch being pulled from is created in oe-core. Because oe-core's
+# submodule update machinery tries to check out a matching branch name,
+# this will cause builds of oe-core on that branch to pull this branch of
+# this repo.
+
+name: 'Build OT3 Image'
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  branch-and-build:
+    name: 'Ensure a matching branch exists in oe-core then build'
+    runs-on: 'ubuntu-18.04'
+    steps:
+      - name: 'Format head ref properly'
+        run: |
+          echo "::set-output name=refname::${GITHUB_HEAD_REF#refs/}"
+          echo "::set-output name=branchname::${GITHUB_HEAD_REF#refs/heads/}"
+          echo "::set-output name=pullnumber::${GITHUB_REF#refs/pulls/}"
+        id: head-ref
+      - name: 'Check if matching branch oe-core/${{ steps.head-ref.outputs.refname}} exists'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: octokit/request-action@v2.x
+        id: check-matching-branch
+        with:
+          route: GET /repos/{owner}/{repo}/git/ref/{ref}
+          owner: opentrons
+          repo: oe-core
+          ref: heads/${{github.head_ref}}
+      - name: 'Create branch: pulling oe-core'
+        if: ${{ steps.check-matching-branch.outputs.status != 200 }}
+        uses: actions/checkout@v2
+        with:
+          depth: 1
+          repository: opentrons/oe-core
+          token: ${{ secrets.CROSSREPO_GH_TOKEN }}
+          ref: main
+          path: oe-core
+      - name: 'making branch and changing submodule ref'
+        if: ${{ steps.check-matching-branch.outputs.status != 200 }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.CROSSREPO_GH_TOKEN }}
+          GIT_USER: ${{github.actor}}:${{secrets.CROSSREPO_GH_TOKEN}}
+        run: |
+          cd oe-core
+          git remote show origin
+          git config --global user.email 'engineering@opentrons.com'
+          git config --global user.name 'Opentrons Github Bot'
+          git config --global user.password ${{ secrets.CROSSREPO_GH_TOKEN }}
+          git checkout -b ${{ steps.head-ref.outputs.branchname }}
+          git submodule set-branch -b ${{ steps.head-ref.outputs.branchname }} layers/meta-opentrons
+          git add --all
+          git commit -F- <<EOF
+          layers/meta-opentrons: ${{steps.head-ref.outputs.branchname}}
+
+          This is an automated commit that sets the tracking-branch of the meta-opentrons
+          submodule to the branch being used in
+          https://github.com/opentrons/meta-opentrons/pulls/${{steps.head-ref.pullnumber}}
+          EOF
+          git push --set-upstream origin ${{ steps.head-ref.outputs.branchname }}
+
+      - name: 'Branch ${{ steps.head-ref.outputs.branchname }} exists, nothing to do'
+        if: ${{ steps.check-matching-branch.outputs.status == 200 }}
+        run: echo ""
+
+      - name: 'Start build'
+        env:
+          GITHUB_TOKEN: ${{ secrets.CROSSREPO_GH_TOKEN }}
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches
+          owner: opentrons
+          repo: oe-core
+          workflow_id: build-ot3.yml
+          ref: ${{ steps.head-ref.outputs.refname }}

--- a/.github/workflows/mainline-builds.yml
+++ b/.github/workflows/mainline-builds.yml
@@ -1,0 +1,25 @@
+# Starts builds based on recent merges to main
+
+name: 'Build OT3 Image'
+
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: 'Start an upstream build'
+    runs-on: 'ubuntu-18.04'
+    steps:
+      - name: 'Start build'
+        env:
+          GITHUB_TOKEN: ${{ secrets.CROSSREPO_GH_TOKEN }}
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches
+          owner: opentrons
+          repo: oe-core
+          workflow_id: build-ot3.yml
+          ref: main

--- a/.github/workflows/remove-upstream-branch.yaml
+++ b/.github/workflows/remove-upstream-branch.yaml
@@ -1,0 +1,59 @@
+# Since we created a branch when the pull request opened, we should close it when
+# the pull request closes - as long as nobody's made changes in the meantime.
+
+name: 'Remove automatically created branches'
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - '*'
+
+jobs:
+  remove-branch:
+    name: 'Remove an automatically-created branch (as long as it has no changes)'
+    runs-on: 'ubuntu-18.04'
+    steps:
+      - name: 'Format head ref properly'
+        run: |
+          echo "::set-output name=refname::${GITHUB_HEAD_REF#refs/}"
+          echo "::set-output name=branchname::${GITHUB_HEAD_REF#refs/heads/}"
+        id: head-ref
+      - name: 'Check if matching branch oe-core/${{ steps.head-ref.outputs.refname}} exists'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: octokit/request-action@v2.x
+        id: check-matching-branch
+        with:
+          route: GET /repos/{owner}/{repo}/git/ref/{ref}
+          owner: opentrons
+          repo: oe-core
+          ref: heads/${{ steps.head-ref.outputs.refname }}
+      - name: 'Branch was deleted elsewhere, nothing to do'
+        if: ${{ steps.check-matching-branch.outputs.status != 200 }}
+        run: echo ""
+      - name: 'Getting oe-core/${{steps.head-ref.outputs.branchname}} HEAD'
+        if: ${{ steps.check-matching-branch.outputs.status == 200 }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: octokit/request-action@v2.x
+        id: get-head-details
+        with:
+          route: GET /repos/{owner}/{repo}/git/commits/{commit_sha}
+          owner: opentrons
+          repo: oe-core
+          commit_sha: ${{ fromJSON(steps.check-matching-branch.outputs.data).object.sha }}
+      - name: 'Author was not us, preserving'
+        if: ${{ (steps.check-matching-branch.outputs.status == 200) && (fromJSON(steps.get-head-details.outputs.data).author.email != 'engineering@opentrons.com')}}
+        run: echo ""
+      - name: 'Removing oe-core/${{steps.head-ref.outputs.refname}}'
+        if: ${{ (steps.check-matching-branch.outputs.status == 200) && (fromJSON(steps.get-head-details.outputs.data).author.email ==  'engineering@opentrons.com') }}
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.CROSSREPO_GH_TOKEN }}
+        with:
+          route: DELETE /repos/{owner}/{repo}/git/refs/{refname}
+          owner: opentrons
+          repo: oe-core
+          refname: heads/${{ steps.head-ref.outputs.refname }}


### PR DESCRIPTION
The problem with a distributed repo system like we have here is that
triggering builds is kind of a pain, especially if you're stubbornly
committed (like I am) to not using a bunch of webhooks and lambdas.

The oe-core repo is where the real CI configuration lives, and where
github actions live to kick off that CI. So let's build some CI here,
which
- when a pull request is opened, reopened, or synched, make a branch
upstream that identifies the current branch in the meta-opentrons
submodule
- starts builds when this pr is synched using the upstream workflow, on
the upstream branch we made
- clean up the branch we made upstream, if we're the only ones that
touched it

So the actual developer workflow should be, "push a meta-opentrons
branch and open a PR for it" and the builds all kick off.

The downside with this chain of workflows is that you don't really get
build outcomes piped back here, that's a next step.