### PR TITLE
chore(ot3): monorepo package fixups

### DIFF
--- a/recipes-robot/python3-robot-api/python3-robot-api_git.bb
+++ b/recipes-robot/python3-robot-api/python3-robot-api_git.bb
@@ -8,8 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 SRC_URI = "git://github.com/Opentrons/opentrons.git;protocol=https;branch=edge;"
 # Modify these as desired
 PV = "1.0+git${SRCPV}"
-#SRCREV = "bf8fbe8a98c14061af8d5bbb22d7a6b95a25eaab"
-SRCREV = "fe4d6db248b2444506e839005e54bf4475d1bdc8"
+SRCREV = "${AUTOREV}"
 inherit setuptools3 insane
 INSANE_SKIP = "arch"
 RDEPENDS_${PN} += " python3-systemd python3-uvicorn python3-numpy python3-typing-extensions python3-jsonschema python3-aionotify python3-pyserial python3-fcntl"

--- a/recipes-robot/python3-robot-server/python3-robot-server_git.bb
+++ b/recipes-robot/python3-robot-server/python3-robot-server_git.bb
@@ -11,7 +11,7 @@ SRC_URI = "git://github.com/Opentrons/opentrons.git;protocol=https;branch=edge;"
 
 # Modify these as desired
 PV = "1.0+git${SRCPV}"
-SRCREV = "30902cc8b2c664aa894f91ab7bb2eaafdefc705a"
+SRCREV = "${AUTOREV}"
 
 inherit setuptools3
 RDEPENDS_${PN} += "python3-fastapi python3-multipart python3-dotenv python3-wsproto python3-typing-extensions python3-starlette python3-pydantic python3-sniffio"

--- a/recipes-robot/python3-robot-shared-data/python3-robot-shared-data_git.bb
+++ b/recipes-robot/python3-robot-shared-data/python3-robot-shared-data_git.bb
@@ -11,7 +11,7 @@ SRC_URI = "git://github.com/Opentrons/opentrons.git;protocol=https;branch=edge;"
 
 # Modify these as desired
 PV = "1.0+git${SRCPV}"
-SRCREV = "fe4d6db248b2444506e839005e54bf4475d1bdc8"
+SRCREV = "${AUTOREV}"
 RDEPENDS_${PN} += "python3-jsonschema"
 S = "${WORKDIR}/git"
 

--- a/recipes-robot/robot-app/robot-app_git.bb
+++ b/recipes-robot/robot-app/robot-app_git.bb
@@ -7,7 +7,7 @@ PV = "1.0+git${SRCPV}"
 
 inherit features_check
 
-SRCREV = "fe4d6db248b2444506e839005e54bf4475d1bdc8"
+SRCREV = "${AUTOREV}"
 S = "${WORKDIR}/git"
 
 inherit insane
@@ -28,7 +28,7 @@ do_compile(){
     make -C app dist
     make -C app-shell lib
     cd ${S}/app-shell
-    yarn run electron-builder --config electron-builder.config.js --linux --arm64 dir
+    yarn run electron-builder --config electron-builder.config.js --linux --arm64 --dir --publish never
 }
 
 fakeroot do_install(){


### PR DESCRIPTION
These are all the packages that come from github.com/opentrons/opentrons
and need to be coversioned with each other but (for most dev workflows)
use the latest head of the branch they come from. Set them all to
autorev.

Also needed to slightly change the electron-builder invocation.