### PR TITLE
chore(robot-server): add pycan dep

### DIFF
--- a/recipes-robot/opentrons-robot-server/opentrons-robot-server_git.bb
+++ b/recipes-robot/opentrons-robot-server/opentrons-robot-server_git.bb
@@ -25,7 +25,7 @@ SRC_URI_append = " file://opentrons-robot-server.service file://opentrons-ot3-ca
 
 PIPENV_APP_BUNDLE_PROJECT_ROOT = "${S}/robot-server"
 PIPENV_APP_BUNDLE_DIR = "/opt/opentrons-robot-server"
-PIPENV_APP_BUNDLE_USE_GLOBAL = "numpy systemd-python"
+PIPENV_APP_BUNDLE_USE_GLOBAL = "numpy systemd-python python-can wrapt"
 PIPENV_APP_BUNDLE_STRIP_HASHES = "yes"
 PIPENV_APP_BUNDLE_EXTRAS = "./../hardware"
 
@@ -45,6 +45,6 @@ do_install_append () {
 
 FILES_${PN}_append = " ${systemd_system_unitdir/opentrons-robot-server.service.d ${systemd_system_unitdir}/opentrons-robot-server.service.d/robot-server-version.conf"
 
-RDEPENDS_${PN} += " python3-numpy python3-systemd nginx"
+RDEPENDS_${PN} += " python3-numpy python3-systemd nginx python-can "
 
 inherit pipenv_app_bundle

--- a/recipes-robot/python-can/python-can_3.3.4.bb
+++ b/recipes-robot/python-can/python-can_3.3.4.bb
@@ -14,5 +14,4 @@ inherit setuptools3
 
 RDEPENDS_${PN} += "python3-aenum python3-wrapt"
 
-RDEPENDS_${PN} += "python3-asyncio python3-core python3-ctypes python3-curses python3-datetime python3-io python3-logging python3-math python3-multiprocessing python3-netclient python3-pickle python3-pkg-resources python3-pyserial python3-six python3-sqlite3 python3-stringold python3-threading python3-typing python3-unittest"
-
+RDEPENDS_${PN} += "python3-asyncio python3-core python3-ctypes python3-curses python3-datetime python3-io python3-logging python3-math python3-multiprocessing python3-netclient python3-pickle python3-pkg-resources python3-pyserial python3-six python3-sqlite3 python3-stringold python3-threading python3-typing "


### PR DESCRIPTION
This isn't captured in the pipfile dependency tree to avoid breaking the
ot2, which means that the change to using pipenv kind of broke things.
We need to add it as a yocto dep.