### PR TITLE
opentrons-robot-server: use ot3 hardware control

### DIFF
--- a/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
+++ b/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
@@ -6,7 +6,7 @@ After=nginx.service
 [Service]
 Type=notify
 ExecStart=python3 -m uvicorn robot_server:app --uds /run/aiohttp.sock --ws wsproto
-Environment=enableOT3HardwareController=true
+Environment=OT_API_FF_enableOT3HardwareController=true
 Environment=RUNNING_ON_PI=true
 Environment=PYTHONPATH=/opt/opentrons-robot-server:/usr/lib/python3.8/site-packages
 Restart=on-failure

--- a/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
+++ b/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
@@ -6,7 +6,7 @@ After=nginx.service
 [Service]
 Type=notify
 ExecStart=python3 -m uvicorn robot_server:app --uds /run/aiohttp.sock --ws wsproto
-Environment=OT_SMOOTHIE_ID=AMA
+Environment=enableOT3HardwareController=true
 Environment=RUNNING_ON_PI=true
 Environment=PYTHONPATH=/opt/opentrons-robot-server:/usr/lib/python3.8/site-packages
 Restart=on-failure


### PR DESCRIPTION
Setting this environment variable should enable the feature flag that
makes the ot3 hardware controller get used.