### PR TITLE
recipes-robot: add opentrons-ot3-hardware

### DIFF
--- a/classes/pipenv_app_bundle.bbclass
+++ b/classes/pipenv_app_bundle.bbclass
@@ -3,14 +3,12 @@
 
 inherit distutils3-base
 
-DEPENDS += "python3 python3-native python3-pip-native "
+DEPENDS += "python3 python3-native python3-pip-native python3-micropipenv-native "
 RDEPENDS_${PN} += " python3 python3-modules"
 
-# Not the coolest thing to do but this is a prepackaged single python file
-# so let's just download it and use it direct
-SRC_URI_append = "\
-  https://raw.githubusercontent.com/thoth-station/micropipenv/v1.1.2/micropipenv.py;md5sum=5627c85023544bae92e620f12a7c5e51"
-
+# Whether pipenv or poetry is the appropriate underlying dependency manager
+# parse
+PIPENV_APP_BUNDLE_PACKAGE_SOURCE ??= "pipenv"
 
 # This should contain a list of python dependencies that should not be
 # installed in the separate directory.  This should be done for packages
@@ -130,7 +128,7 @@ do_configure_prepend () {
    else
        HASHES="--no-hashes"
    fi
-   ${PYTHON} ${WORKDIR}/micropipenv.py requirements --no-dev ${HASHES} > ${B}/requirements-unfiltered.txt
+   ${PYTHON} -m micropipenv requirements --method ${PIPENV_APP_BUNDLE_PACKAGE_SOURCE} --no-dev ${HASHES} > ${B}/requirements-unfiltered.txt
 }
 
 do_configure[vardeps] += "PIPENV_APP_BUNDLE_STRIP_HASHES PIPENV_APP_BUNDLE_PROJECT_ROOT"

--- a/recipes-devtools/python3-micropipenv/python3-micropipenv-native_1.2.0.bb
+++ b/recipes-devtools/python3-micropipenv/python3-micropipenv-native_1.2.0.bb
@@ -1,0 +1,12 @@
+SUMMARY = "A simple wrapper around pip to support requirements.txt, Pipenv and Poetry files for containerized applications"
+LICENSE = " LGPL-3.0-only"
+HOMEPAGE = "https://github.com/thoth-station/micropipenv"
+LIC_FILES_CHKSUM = "file://LICENSE-LGPL;md5=3000208d539ec061b899bce1d9ce9404"
+
+SRC_URI[sha256sum] = "275e84b3e8227fb585a050ce4f333539ed1096e76b09340649abca475d3151ca"
+SRC_URI[md5sum] = "c5f390bcd97d7089e26099dd746ff838"
+S = "${WORKDIR}/micropipenv-${PV}"
+
+DEPENDS = "python3-native python3-toml-native "
+
+inherit native setuptools3 pypi

--- a/recipes-devtools/python3-micropipenv/python3-toml-native_0.10.2.bb
+++ b/recipes-devtools/python3-micropipenv/python3-toml-native_0.10.2.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Python Library for Tom's Obvious, Minimal Language"
+LICENSE = "MIT"
+HOMEPAGE = "https://github.com/uiri/toml"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=16c77b2b1050d2f03cb9c2ed0edaf4f0"
+
+SRC_URI[sha256sum] = "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+SRC_URI[md5sum] = "59bce5d8d67e858735ec3f399ec90253"
+S = "${WORKDIR}/toml-${PV}"
+
+DEPENDS = "python3-native "
+
+inherit native setuptools3 pypi

--- a/recipes-robot/opentrons-robot-server/opentrons-ot3-hardware_git.bb
+++ b/recipes-robot/opentrons-robot-server/opentrons-ot3-hardware_git.bb
@@ -1,0 +1,23 @@
+# Copyright (C) 2021 Seth Foster <seth@opentrons.com>
+# Released under the MIT License (see COPYING.MIT for the terms)
+DESCRIPTION = "Firmware bindings for canbus messages for OT3"
+HOMEPAGE = "https://github.com/Opentrons/ot3-firmware"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
+PV = "1.0+git${SRCPV}"
+SRCREV = "${AUTOREV}"
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
+BRANCH = "main"
+inherit insane
+SRC_URI = "git://github.com/Opentrons/ot3-firmware.git;protocol=https;branch=${BRANCH};"
+
+PIPENV_APP_BUNDLE_PROJECT_ROOT = "${S}/python"
+PIPENV_APP_BUNDLE_DIR = "/opt/opentrons-robot-server"
+PIPENV_APP_BUNDLE_USE_GLOBAL = "typing-extensions"
+PIPENV_APP_BUNDLE_STRIP_HASHES = "yes"
+PIPENV_APP_BUNDLE_EXTRAS = ""
+PIPENV_APP_BUNDLE_PACKAGE_SOURCE = "poetry"
+
+inherit pipenv_app_bundle
+FILES_${PN} = "${PIPENV_APP_BUNDLE_DIR}/opentrons_ot3_firmware ${PIPENV_APP_BUNDLE_DIR}/opentrons_ot3_firmware-*.dist-info"

--- a/recipes-robot/opentrons-robot-server/opentrons-robot-server_git.bb
+++ b/recipes-robot/opentrons-robot-server/opentrons-robot-server_git.bb
@@ -45,6 +45,6 @@ do_install_append () {
 
 FILES_${PN}_append = " ${systemd_system_unitdir/opentrons-robot-server.service.d ${systemd_system_unitdir}/opentrons-robot-server.service.d/robot-server-version.conf"
 
-RDEPENDS_${PN} += " python3-numpy python3-systemd nginx python-can "
+RDEPENDS_${PN} += " python3-numpy python3-systemd nginx python-can opentrons-ot3-hardware "
 
 inherit pipenv_app_bundle


### PR DESCRIPTION
We'll need the python package from https://github.com/Opentrons/opentrons-ot3-firmware in the robot server path since it provides constants and structure for canbus methods that the monorepo now relies upon. After changing the way we install micropipenv so it supports poetry, we can just add a quick little recipe that installs it.

The recipe and package are named opentrons-ot3-hardware, which could be better I suppose; didn't want it to be opentrons-ot3-firmware because at some point we'll have a package by that name providing firmware images for connected microcontrollers for provisioning at system boot.