### PR TITLE
fix: aiohttp global

### DIFF
--- a/recipes-robot/opentrons-update-server/opentrons-update-server_git.bb
+++ b/recipes-robot/opentrons-update-server/opentrons-update-server_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 SRC_URI = "git://github.com/Opentrons/opentrons.git;protocol=https;branch=edge;"
 
-RDEPENDS_${PN} += " bmap-tools libubootenv nginx python3-dbus"
+RDEPENDS_${PN} += " bmap-tools libubootenv nginx python3-dbus python-aiohttp"
 
 # Modify these as desired
 PV = "1.0+git${SRCPV}"
@@ -23,5 +23,6 @@ PIPENV_APP_BUNDLE_PROJECT_ROOT = "${S}/update-server"
 PIPENV_APP_BUNDLE_DIR = "/opt/opentrons-update-server"
 PIPENV_APP_BUNDLE_STRIP_HASHES = "yes"
 PIPENV_APP_BUNDLE_EXTRAS = ""
+PIPENV_APP_BUNDLE_USE_GLOBAL = "python-aiohttp"
 
 inherit pipenv_app_bundle

--- a/recipes-robot/opentrons-update-server/opentrons-update-server_git.bb
+++ b/recipes-robot/opentrons-update-server/opentrons-update-server_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 SRC_URI = "git://github.com/Opentrons/opentrons.git;protocol=https;branch=edge;"
 
-RDEPENDS_${PN} += " bmap-tools libubootenv nginx python3-dbus python-aiohttp"
+RDEPENDS_${PN} += " bmap-tools libubootenv nginx python3-dbus python3-aiohttp"
 
 # Modify these as desired
 PV = "1.0+git${SRCPV}"
@@ -23,6 +23,6 @@ PIPENV_APP_BUNDLE_PROJECT_ROOT = "${S}/update-server"
 PIPENV_APP_BUNDLE_DIR = "/opt/opentrons-update-server"
 PIPENV_APP_BUNDLE_STRIP_HASHES = "yes"
 PIPENV_APP_BUNDLE_EXTRAS = ""
-PIPENV_APP_BUNDLE_USE_GLOBAL = "python-aiohttp"
+PIPENV_APP_BUNDLE_USE_GLOBAL = "python3-aiohttp"
 
 inherit pipenv_app_bundle

--- a/recipes-robot/python-aiohttp/python-aiohttp_3.4.4.bb
+++ b/recipes-robot/python-aiohttp/python-aiohttp_3.4.4.bb
@@ -1,0 +1,16 @@
+
+SUMMARY = "Async http client/server framework (asyncio)"
+HOMEPAGE = "https://github.com/aio-libs/aiohttp"
+AUTHOR = "Nikolay Kim <fafhrd91@gmail.com>"
+LICENSE = "Apache 2"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=c76b717025e9f23e50092cd39a213d56"
+
+SRC_URI = "https://files.pythonhosted.org/packages/70/27/6098b4b60a3302a97f8ec97eb85d42f55a2fa904da4a369235a8e3b84352/aiohttp-3.4.4.tar.gz"
+SRC_URI[md5sum] = "80a6e0c6c452d511d1d37755d6f0995a"
+SRC_URI[sha256sum] = "51afec6ffa50a9da4cdef188971a802beb1ca8e8edb40fa429e5e529db3475fa"
+
+S = "${WORKDIR}/aiohttp-3.4.4"
+
+RDEPENDS_${PN} = "python-attrs python-chardet python-multidict python-async-timeout python-yarl"
+
+inherit setuptools

--- a/recipes-robot/python-aiohttp/python3-aiohttp_3.4.4.bb
+++ b/recipes-robot/python-aiohttp/python3-aiohttp_3.4.4.bb
@@ -11,6 +11,6 @@ SRC_URI[sha256sum] = "51afec6ffa50a9da4cdef188971a802beb1ca8e8edb40fa429e5e529db
 
 S = "${WORKDIR}/aiohttp-3.4.4"
 
-RDEPENDS_${PN} = "python-attrs python-chardet python-multidict python-async-timeout python-yarl"
+RDEPENDS_${PN} = "python3-attrs python3-chardet python3-multidict python3-async-timeout python3-yarl"
 
-inherit setuptools
+inherit setuptools3


### PR DESCRIPTION
This is a stop gap to get the update-server to work. 

`aiohttp` has native code. It was not being built correctly by the pipenv script, so this PR adds a yocto recipe for build `aiohttp`.

*Not tested on toradex. Only validated that the build works and that `aiohttp` is built globally.*

SO files look correctly named now.
```
-rwxr-xr-x  1 ubuntu ubuntu  70768 Mar  9  2018 _frozenlist.cpython-38-aarch64-linux-gnu.so*
-rw-r--r--  1 ubuntu ubuntu   2605 Mar  9  2018 _frozenlist.pyx
-rw-r--r--  1 ubuntu ubuntu   2027 Mar  9  2018 _headers.pxi
-rw-r--r--  1 ubuntu ubuntu 208656 Mar  9  2018 _helpers.c
-rwxr-xr-x  1 ubuntu ubuntu  49024 Mar  9  2018 _helpers.cpython-38-aarch64-linux-gnu.so*
-rw-r--r--  1 ubuntu ubuntu    204 Mar  9  2018 _helpers.pyi
```