### PR TITLE
refactor(ot3): Set bit timings for 500kbaud

### DIFF
--- a/recipes-robot/opentrons-robot-server/files/opentrons-ot3-canbus.service
+++ b/recipes-robot/opentrons-robot-server/files/opentrons-ot3-canbus.service
@@ -4,9 +4,29 @@ After=sys-subsystem-net-devices-can0.device
 
 [Service]
 Type=oneshot
+Environment=TIME_QUANTUM_NS=100\
+    PROP_PHASE_TQ=8\
+    PHASE_SEG1_TQ=7\
+    PHASE_SEG2_TQ=4\
+    SJW_TQ=1\
+
 ExecStartPre=modprobe can
 ExecStartPre=modprobe can-raw
-ExecStart=ip link set can0 up type can restart-ms 100 bitrate 250000 dbitrate 250000 fd on
+ExecStart=ip link set can0 up\
+    type can\
+    restart-ms 100\
+    fd on\
+    tq $TIME_QUANTUM_NS\
+    prop-seg $PROP_PHASE_TQ\
+    phase-seg1 $PHASE_SEG1_TQ\
+    phase-seg2 $PHASE_SEG2_TQ\
+    sjw $SJW_TQ\
+    dtq $TIME_QUANTUM_NS \
+    dprop-seg $PROP_PHASE_TQ\
+    dphase-seg1 $PHASE_SEG1_TQ\
+    dphase-seg2 $PHASE_SEG2_TQ\
+    dsjw $SJW_TQ\
+
 ExecStop=ip link set can0 down
 RemainAfterExit=true
 Restart=on-failure


### PR DESCRIPTION
These bit timings can be achieved exactly by all microcontrollers as
well as the MCP2518, which is important because they all need to be
within 0.5%. We could also specify bit timings via (bitrate,
sample-point), but then we might generate the wrong ones so doing it
via (tq, prop-seg, phase-seg1, phase-seg2) offers more control. It also
requires a lot more settings, so reorganize the systemd service to be a
little more friendly to reading and editing.

Note - won't merge this until a network stress test is performed.

This pr will require https://github.com/Opentrons/ot3-firmware/pull/349 to be merged and running on all microcontrollers for proper canbus communication.