### PR TITLE
fix(ot3): native zip

### DIFF
--- a/recipes-images/images/opentrons-ot3-image.bb
+++ b/recipes-images/images/opentrons-ot3-image.bb
@@ -10,6 +10,7 @@ export IMAGE_BASENAME = "opentrons-ot3-image"
 MACHINE_NAME ?= "${MACHINE}"
 IMAGE_NAME = "${MACHINE_NAME}_${IMAGE_BASENAME}"
 
+do_image_zip[depends] = "zip-native:do_populate_sysroot"
 python __anonymous () {
     bb.build.addtask('do_image_zip', 'do_image_complete', 'do_image_ext4', d)
 }
@@ -56,6 +57,6 @@ IMAGE_INSTALL += " \
 
 do_image_zip() {
     cd ${DEPLOY_DIR_IMAGE}/
-    sha256sum opentrons-ot3-image-verdin-imx8mm.ext4.xz > rootfs.xz.256
-    zip ot3-system.zip opentrons-ot3-image-verdin-imx8mm.ext4.xz rootfs.xz.256
+    sha256sum Verdin-iMX8MM_opentrons-ot3-image.rootfs.ext4.xz > rootfs.xz.256
+    zip ot3-system.zip Verdin-iMX8MM_opentrons-ot3-image.rootfs.ext4.xz rootfs.xz.256
 }

--- a/recipes-images/images/opentrons-ot3-image.bb
+++ b/recipes-images/images/opentrons-ot3-image.bb
@@ -11,9 +11,7 @@ MACHINE_NAME ?= "${MACHINE}"
 IMAGE_NAME = "${MACHINE_NAME}_${IMAGE_BASENAME}"
 
 do_image_zip[depends] = "zip-native:do_populate_sysroot"
-python __anonymous () {
-    bb.build.addtask('do_image_zip', 'do_image_complete', 'do_image_ext4', d)
-}
+addtask do_image_zip after do_image_complete before do_populate_lic_deploy
 # Copy Licenses to image /usr/share/common-license
 COPY_LIC_MANIFEST ?= "1"
 COPY_LIC_DIRS ?= "1"
@@ -57,7 +55,8 @@ IMAGE_INSTALL += " \
 
 do_image_zip() {
     cd ${DEPLOY_DIR_IMAGE}/
-    ls -l *.xz
-    sha256sum  ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.xz > rootfs.xz.256
-    zip ot3-system.zip  ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.xz rootfs.xz.256
+    /bin/pwd
+    ls -l
+    sha256sum ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.ext4.xz > rootfs.xz.256
+    zip ot3-system.zip ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.ext4.xz rootfs.xz.256
 }

--- a/recipes-images/images/opentrons-ot3-image.bb
+++ b/recipes-images/images/opentrons-ot3-image.bb
@@ -58,6 +58,6 @@ IMAGE_INSTALL += " \
 do_image_zip() {
     cd ${DEPLOY_DIR_IMAGE}/
     ls -l *.xz
-    sha256sum  ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.xz.xz > rootfs.xz.256
-    zip ot3-system.zip  ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.xz.xz rootfs.xz.256
+    sha256sum  ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.xz > rootfs.xz.256
+    zip ot3-system.zip  ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.xz rootfs.xz.256
 }

--- a/recipes-images/images/opentrons-ot3-image.bb
+++ b/recipes-images/images/opentrons-ot3-image.bb
@@ -57,6 +57,7 @@ IMAGE_INSTALL += " \
 
 do_image_zip() {
     cd ${DEPLOY_DIR_IMAGE}/
-    sha256sum Verdin-iMX8MM_opentrons-ot3-image.rootfs.ext4.xz > rootfs.xz.256
-    zip ot3-system.zip Verdin-iMX8MM_opentrons-ot3-image.rootfs.ext4.xz rootfs.xz.256
+    ls -l *.xz
+    sha256sum  ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.xz.xz > rootfs.xz.256
+    zip ot3-system.zip  ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.xz.xz rootfs.xz.256
 }

--- a/recipes-robot/opentrons-update-server/opentrons-update-server_git.bb
+++ b/recipes-robot/opentrons-update-server/opentrons-update-server_git.bb
@@ -7,8 +7,7 @@
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-# TODO (amitl, 2022-03-21): MOVE BACK TO EDGE!!!
-SRC_URI = "git://github.com/Opentrons/opentrons.git;protocol=https;branch=RET-71-ot3-update-server;"
+SRC_URI = "git://github.com/Opentrons/opentrons.git;protocol=https;branch=edge;"
 
 RDEPENDS_${PN} += " bmap-tools libubootenv nginx python3-dbus python3-aiohttp python3-systemd"
 


### PR DESCRIPTION
Will make sure ci builds images before merging this.
Have do_image_zip depend on native zip. Also don't use symbolic link for rootfs files. 