### PR TITLE
recipes-robot/robot-app: use system python

### DIFF
--- a/recipes-robot/robot-app/robot-app-wayland-launch_1.0.bb
+++ b/recipes-robot/robot-app/robot-app-wayland-launch_1.0.bb
@@ -18,9 +18,9 @@ SRC_URI = " \
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-APPLICATION_ENVIRONMENT := '\"DISPLAY=\:0\:0\" \"XDG_SESSION_TYPE=wayland\" \"XDG_SESSION_DESKTOP=kiosk\"'
+APPLICATION_ENVIRONMENT := '\"DISPLAY=\:0\:0\" \"XDG_SESSION_TYPE=wayland\" \"XDG_SESSION_DESKTOP=kiosk\" \"PYTHONPATH=/opt/opentrons-robot-server\"'
 
-WAYLAND_APPLICATION := "/opt/opentrons-app/opentrons --discovery.candidates=localhost --discovery.ipFilter=\"127.0.0.1\" --no-sandbox --enable-features=UseOzonePlatform --ozone-platform=wayland --in-process-gpu"
+WAYLAND_APPLICATION := "/opt/opentrons-app/opentrons --discovery.candidates=localhost --discovery.ipFilter=\"127.0.0.1\" --no-sandbox --enable-features=UseOzonePlatform --ozone-platform=wayland --in-process-gpu --python.pathToPythonOverride=/usr/bin/python"
 
 do_compile () {
     sed -e "s:@@wayland-application@@:${WAYLAND_APPLICATION}:" -e "s:@@initial-path@@:${INITIAL_PATH}:" opentrons-robot-app.sh.in > opentrons-robot-app.sh

--- a/recipes-robot/robot-app/robot-app_git.bb
+++ b/recipes-robot/robot-app/robot-app_git.bb
@@ -1,6 +1,6 @@
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
-SRC_URI = "git://github.com/Opentrons/opentrons.git;protocol=https;branch=edge; "
+SRC_URI = "git://github.com/Opentrons/opentrons.git;protocol=https;branch=;optionally-install-python "
 
 # Modify these as desired
 PV = "1.0+git${SRCPV}"

--- a/recipes-robot/robot-app/robot-app_git.bb
+++ b/recipes-robot/robot-app/robot-app_git.bb
@@ -28,7 +28,7 @@ do_compile(){
     make -C app dist
     make -C app-shell lib
     cd ${S}/app-shell
-    yarn run electron-builder --config electron-builder.config.js --linux --arm64 --dir --publish never
+    NODE_ENV=production NO_PYTHON=true yarn run electron-builder --config electron-builder.config.js --linux --arm64 --dir --publish never
 }
 
 fakeroot do_install(){


### PR DESCRIPTION
The app added the capability to analyze protocols offline by bundling a standalone python interpreter and all the modules required for protocol analysis into itself. That's a problem in builds for the robot because we really don't want to deal with cross-compiling all that stuff and don't want to duplicate all the code. Instead, we can tell the builder not to actually grab the python stuff, and tell the app at runtime to use the system interpreter and the python modules from the robot server.

DO NOT MERGE THIS PR until you have undone the branch switch commit.