### PR TITLE
RET-1197 Create filesystem tar.xz and ext4.xz files required for tezi and ot3-system.zip

### DIFF
--- a/conf/machine/verdin-imx8mm.conf
+++ b/conf/machine/verdin-imx8mm.conf
@@ -76,7 +76,7 @@ MACHINE_FIRMWARE_append = " firmware-imx-vpu-imx8"
 BOARD_TYPE = "verdin"
 
 IMAGE_CLASSES_append = " image_type_tezi_ot3"
-IMAGE_FSTYPES += "teziimg ext4 ext4.xz"
+IMAGE_FSTYPES += "teziimg ext4.xz"
 
 UBOOT_BINARY_TEZI_EMMC = "imx-boot"
 OFFSET_BOOTROM_PAYLOAD = "2"


### PR DESCRIPTION
[RET-1197](https://opentrons.atlassian.net/browse/RET-1197)

Creates the required filesystem compressions for tezi image and ot3-system.zip 

**Changes**
- creates the tar.xz files of the systemfs and userfs required by tezi
- creates the ext4.xz of the systemfs required for ot3-system.zip
- bundle systemfs.ext4.xz and sha256sum in the ot3-system.zip