### PR TITLE
recipes-robot/opentrons-robot-server: persist db

### DIFF
--- a/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
+++ b/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
@@ -9,6 +9,7 @@ ExecStart=python3 -m uvicorn robot_server:app --uds /run/aiohttp.sock --ws wspro
 Environment=OT_API_FF_enableOT3HardwareController=true
 Environment=RUNNING_ON_PI=true
 Environment=PYTHONPATH=/opt/opentrons-robot-server:/usr/lib/python3.8/site-packages
+Environment=OT_ROBOT_SERVER_persistence_directory=/var/lib/robot-server
 Restart=on-failure
 TimeoutStartSec=3min
 After=opentrons-ot3-canbus

--- a/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
+++ b/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
@@ -6,10 +6,11 @@ After=nginx.service
 [Service]
 Type=notify
 ExecStart=python3 -m uvicorn robot_server:app --uds /run/aiohttp.sock --ws wsproto
+StateDirectory=opentrons-robot-server
 Environment=OT_API_FF_enableOT3HardwareController=true
 Environment=RUNNING_ON_PI=true
 Environment=PYTHONPATH=/opt/opentrons-robot-server:/usr/lib/python3.8/site-packages
-Environment=OT_ROBOT_SERVER_persistence_directory=/var/lib/robot-server
+Environment=OT_ROBOT_SERVER_persistence_directory=$STATE_DIRECTORY
 Restart=on-failure
 TimeoutStartSec=3min
 After=opentrons-ot3-canbus

--- a/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
+++ b/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
@@ -10,7 +10,7 @@ StateDirectory=opentrons-robot-server
 Environment=OT_API_FF_enableOT3HardwareController=true
 Environment=RUNNING_ON_PI=true
 Environment=PYTHONPATH=/opt/opentrons-robot-server:/usr/lib/python3.8/site-packages
-Environment=OT_ROBOT_SERVER_persistence_directory=$STATE_DIRECTORY
+Environment=OT_ROBOT_SERVER_persistence_directory=%S/opentrons-robot-server
 Restart=on-failure
 TimeoutStartSec=3min
 After=opentrons-ot3-canbus


### PR DESCRIPTION
Need to specify the robot server database directory for the machine to
persist data.

This PR places the persistence directory in `/var/lib/opentrons-robot-server`. This is the correct place as far as linux best practices are concerned; it is what systemd calls the "state directory", and its presence is managed by systemd.