### PR TITLE
recipes: use gdk-pixbuf 2.42.9

### DIFF
--- a/conf/machine/verdin-imx8mm.conf
+++ b/conf/machine/verdin-imx8mm.conf
@@ -66,10 +66,13 @@ PREFERRED_PROVIDER_virtual/kernel = "linux-toradex"
 PREFERRED_PROVIDER_virtual/kernel_preempt-rt = "linux-toradex"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-toradex"
 PREFERRED_PROVIDER_u-boot = "u-boot-toradex"
+
 # Currently we use the nxp 2020.04 downstream for mx8 as some features are
 # not yet available in 2020.07.
 PREFERRED_VERSION_u-boot-toradex = "2020.04%"
-
+# Updated gdk-pixbuf required for electron >=19
+PREFERRED_VERSION_gdk-pixbuf = "2.42.9"
+PREFERRED_VERSION_meson-native = "0.55.3"
 MACHINE_FIRMWARE_append = " linux-firmware-sd8997"
 MACHINE_FIRMWARE_append = " firmware-imx-vpu-imx8"
 

--- a/recipes-devtools/meson/meson/0001-Make-CPU-family-warnings-fatal.patch
+++ b/recipes-devtools/meson/meson/0001-Make-CPU-family-warnings-fatal.patch
@@ -1,0 +1,41 @@
+From 9311844b6c422479556e83b89a8e675ebcb2056c Mon Sep 17 00:00:00 2001
+From: Ross Burton <ross.burton@intel.com>
+Date: Tue, 3 Jul 2018 13:59:09 +0100
+Subject: [PATCH] Make CPU family warnings fatal
+
+Upstream-Status: Inappropriate [OE specific]
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+---
+ mesonbuild/envconfig.py   | 2 +-
+ mesonbuild/environment.py | 4 +---
+ 2 files changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/mesonbuild/envconfig.py b/mesonbuild/envconfig.py
+index 219b62e..d1be65b 100644
+--- a/mesonbuild/envconfig.py
++++ b/mesonbuild/envconfig.py
+@@ -199,7 +199,7 @@ class MachineInfo:
+ 
+         cpu_family = literal['cpu_family']
+         if cpu_family not in known_cpu_families:
+-            mlog.warning('Unknown CPU family {}, please report this at https://github.com/mesonbuild/meson/issues/new'.format(cpu_family))
++            raise EnvironmentException('Unknown CPU family {}, see https://wiki.yoctoproject.org/wiki/Meson/UnknownCPU for directions.'.format(cpu_family))
+ 
+         endian = literal['endian']
+         if endian not in ('little', 'big'):
+diff --git a/mesonbuild/environment.py b/mesonbuild/environment.py
+index bf09a88..8eabe78 100644
+--- a/mesonbuild/environment.py
++++ b/mesonbuild/environment.py
+@@ -375,9 +375,7 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
+         trial = 'parisc'
+ 
+     if trial not in known_cpu_families:
+-        mlog.warning('Unknown CPU family {!r}, please report this at '
+-                     'https://github.com/mesonbuild/meson/issues/new with the '
+-                     'output of `uname -a` and `cat /proc/cpuinfo`'.format(trial))
++        raise EnvironmentException('Unknown CPU family %s, see https://wiki.yoctoproject.org/wiki/Meson/UnknownCPU for directions.' % trial)
+ 
+     return trial
+ 

--- a/recipes-devtools/meson/meson/0001-gnome.py-prefix-g-i-paths-with-PKG_CONFIG_SYSROOT_DI.patch
+++ b/recipes-devtools/meson/meson/0001-gnome.py-prefix-g-i-paths-with-PKG_CONFIG_SYSROOT_DI.patch
@@ -1,0 +1,37 @@
+From 64aa6718c290e150dafd8da83f31cb08af00af0e Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Wed, 27 May 2020 16:43:05 +0000
+Subject: [PATCH] gnome.py: prefix g-i paths with PKG_CONFIG_SYSROOT_DIR
+
+When using sysroots for builds, the standard target paths for the
+tools need to be prefixed (pkg-config is not clever enough to
+determine when a custom variable is a path)
+
+Upstream-Status: Pending
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+
+---
+ mesonbuild/modules/gnome.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mesonbuild/modules/gnome.py b/mesonbuild/modules/gnome.py
+index 52016f4..2b72ee4 100644
+--- a/mesonbuild/modules/gnome.py
++++ b/mesonbuild/modules/gnome.py
+@@ -410,14 +410,14 @@ class GnomeModule(ExtensionModule):
+             if giscanner is not None:
+                 self.giscanner = ExternalProgram.from_entry('g-ir-scanner', giscanner)
+             elif self.gir_dep.type_name == 'pkgconfig':
+-                self.giscanner = ExternalProgram('g_ir_scanner', self.gir_dep.get_pkgconfig_variable('g_ir_scanner', {}))
++                self.giscanner = ExternalProgram('g_ir_scanner', os.environ['PKG_CONFIG_SYSROOT_DIR'] + self.gir_dep.get_pkgconfig_variable('g_ir_scanner', {}))
+             else:
+                 self.giscanner = self.interpreter.find_program_impl('g-ir-scanner')
+             gicompiler = state.environment.lookup_binary_entry(MachineChoice.HOST, 'g-ir-compiler')
+             if gicompiler is not None:
+                 self.gicompiler = ExternalProgram.from_entry('g-ir-compiler', gicompiler)
+             elif self.gir_dep.type_name == 'pkgconfig':
+-                self.gicompiler = ExternalProgram('g_ir_compiler', self.gir_dep.get_pkgconfig_variable('g_ir_compiler', {}))
++                self.gicompiler = ExternalProgram('g_ir_compiler', os.environ['PKG_CONFIG_SYSROOT_DIR'] + self.gir_dep.get_pkgconfig_variable('g_ir_compiler', {}))
+             else:
+                 self.gicompiler = self.interpreter.find_program_impl('g-ir-compiler')
+         return self.gir_dep, self.giscanner, self.gicompiler

--- a/recipes-devtools/meson/meson/0001-gtkdoc-fix-issues-that-arise-when-cross-compiling.patch
+++ b/recipes-devtools/meson/meson/0001-gtkdoc-fix-issues-that-arise-when-cross-compiling.patch
@@ -1,0 +1,36 @@
+From d3ef01a4208a801acad380a4aaceb6a21f8fa603 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Fri, 4 Aug 2017 16:16:41 +0300
+Subject: [PATCH] gtkdoc: fix issues that arise when cross-compiling
+
+Specifically:
+1) Make it possible to specify a wrapper for executing binaries
+(usually, some kind of target hardware emulator, such as qemu)
+2) Explicitly provide CC and LD via command line, as otherwise gtk-doc will
+try to guess them, incorrectly.
+3) If things break down, print the full command with arguments,
+not just the binary name.
+4) Correctly determine the compiler/linker executables and cross-options when cross-compiling
+
+Upstream-Status: Pending
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+
+---
+ mesonbuild/modules/gnome.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/mesonbuild/modules/gnome.py b/mesonbuild/modules/gnome.py
+index bcf77b9..6a4b472 100644
+--- a/mesonbuild/modules/gnome.py
++++ b/mesonbuild/modules/gnome.py
+@@ -974,6 +974,10 @@ This will become a hard error in the future.''')
+             args.append('--{}={}'.format(program_name, path))
+         if namespace:
+             args.append('--namespace=' + namespace)
++        gtkdoc_exe_wrapper = state.environment.properties.host.get('gtkdoc_exe_wrapper', None)
++        if gtkdoc_exe_wrapper is not None:
++            args.append('--run=' + gtkdoc_exe_wrapper)
++
+         args += self._unpack_args('--htmlargs=', 'html_args', kwargs)
+         args += self._unpack_args('--scanargs=', 'scan_args', kwargs)
+         args += self._unpack_args('--scanobjsargs=', 'scanobjs_args', kwargs)

--- a/recipes-devtools/meson/meson/0001-modules-python.py-do-not-substitute-python-s-install.patch
+++ b/recipes-devtools/meson/meson/0001-modules-python.py-do-not-substitute-python-s-install.patch
@@ -1,0 +1,45 @@
+From 214e559d394491b1376e4cc370f75151117a3f83 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Thu, 18 Apr 2019 17:36:11 +0200
+Subject: [PATCH] modules/python.py: do not substitute python's install prefix
+ with meson's
+
+Not sure why this is being done, but it
+a) relies on Python's internal variable substitution which may break in the future
+b) shouldn't be necessary as Python's prefix ought to be correct in the first place
+
+Upstream-Status: Pending
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+
+---
+ mesonbuild/modules/python.py | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/mesonbuild/modules/python.py b/mesonbuild/modules/python.py
+index 2f0c644..d2aa565 100644
+--- a/mesonbuild/modules/python.py
++++ b/mesonbuild/modules/python.py
+@@ -251,7 +251,7 @@ INTROSPECT_COMMAND = '''import sysconfig
+ import json
+ import sys
+ 
+-install_paths = sysconfig.get_paths(scheme='posix_prefix', vars={'base': '', 'platbase': '', 'installed_base': ''})
++install_paths = sysconfig.get_paths(scheme='posix_prefix')
+ 
+ def links_against_libpython():
+     from distutils.core import Distribution, Extension
+@@ -276,12 +276,11 @@ class PythonInstallation(ExternalProgramHolder):
+         ExternalProgramHolder.__init__(self, python, interpreter.subproject)
+         self.interpreter = interpreter
+         self.subproject = self.interpreter.subproject
+-        prefix = self.interpreter.environment.coredata.get_builtin_option('prefix')
+         self.variables = info['variables']
+         self.paths = info['paths']
+         install_paths = info['install_paths']
+-        self.platlib_install_path = os.path.join(prefix, install_paths['platlib'][1:])
+-        self.purelib_install_path = os.path.join(prefix, install_paths['purelib'][1:])
++        self.platlib_install_path = install_paths['platlib']
++        self.purelib_install_path = install_paths['purelib']
+         self.version = info['version']
+         self.platform = info['platform']
+         self.is_pypy = info['is_pypy']

--- a/recipes-devtools/meson/meson/0001-python-module-do-not-manipulate-the-environment-when.patch
+++ b/recipes-devtools/meson/meson/0001-python-module-do-not-manipulate-the-environment-when.patch
@@ -1,0 +1,43 @@
+From 689e28c49b85311f93f39df70cbee702fc44afb6 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Mon, 19 Nov 2018 14:24:26 +0100
+Subject: [PATCH] python module: do not manipulate the environment when calling
+ pkg-config
+
+Upstream-Status: Inappropriate [oe-core specific]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+
+---
+ mesonbuild/modules/python.py | 12 ------------
+ 1 file changed, 12 deletions(-)
+
+diff --git a/mesonbuild/modules/python.py b/mesonbuild/modules/python.py
+index 07be318..b770603 100644
+--- a/mesonbuild/modules/python.py
++++ b/mesonbuild/modules/python.py
+@@ -71,11 +71,6 @@ class PythonDependency(ExternalDependency):
+                 old_pkg_libdir = os.environ.get('PKG_CONFIG_LIBDIR')
+                 old_pkg_path = os.environ.get('PKG_CONFIG_PATH')
+ 
+-                os.environ.pop('PKG_CONFIG_PATH', None)
+-
+-                if pkg_libdir:
+-                    os.environ['PKG_CONFIG_LIBDIR'] = pkg_libdir
+-
+                 try:
+                     self.pkgdep = PkgConfigDependency(pkg_name, environment, kwargs)
+                     mlog.debug('Found "{}" via pkgconfig lookup in LIBPC ({})'.format(pkg_name, pkg_libdir))
+@@ -84,13 +79,6 @@ class PythonDependency(ExternalDependency):
+                     mlog.debug('"{}" could not be found in LIBPC ({})'.format(pkg_name, pkg_libdir))
+                     mlog.debug(e)
+ 
+-                if old_pkg_path is not None:
+-                    os.environ['PKG_CONFIG_PATH'] = old_pkg_path
+-
+-                if old_pkg_libdir is not None:
+-                    os.environ['PKG_CONFIG_LIBDIR'] = old_pkg_libdir
+-                else:
+-                    os.environ.pop('PKG_CONFIG_LIBDIR', None)
+             else:
+                 mlog.debug('"{}" could not be found in LIBPC ({}), this is likely due to a relocated python installation'.format(pkg_name, pkg_libdir))
+ 

--- a/recipes-devtools/meson/meson/0002-Support-building-allarch-recipes-again.patch
+++ b/recipes-devtools/meson/meson/0002-Support-building-allarch-recipes-again.patch
@@ -1,0 +1,26 @@
+From 38f59e256f760aa959c13f4c5713f87ff7addee5 Mon Sep 17 00:00:00 2001
+From: Peter Kjellerstedt <pkj@axis.com>
+Date: Thu, 26 Jul 2018 16:32:49 +0200
+Subject: [PATCH] Support building allarch recipes again
+
+This registers "allarch" as a known CPU family.
+
+Upstream-Status: Inappropriate [OE specific]
+Signed-off-by: Peter Kjellerstedt <peter.kjellerstedt@axis.com>
+
+---
+ mesonbuild/envconfig.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/mesonbuild/envconfig.py b/mesonbuild/envconfig.py
+index d1be65b..90f3573 100644
+--- a/mesonbuild/envconfig.py
++++ b/mesonbuild/envconfig.py
+@@ -36,6 +36,7 @@ _T = T.TypeVar('_T')
+ 
+ 
+ known_cpu_families = (
++    'allarch',
+     'aarch64',
+     'alpha',
+     'arc',

--- a/recipes-devtools/meson/meson/0003-native_bindir.patch
+++ b/recipes-devtools/meson/meson/0003-native_bindir.patch
@@ -1,0 +1,125 @@
+From f06c89939d0d006090a8a8728b2a13d532b83047 Mon Sep 17 00:00:00 2001
+From: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>
+Date: Wed, 15 Nov 2017 15:05:01 +0100
+Subject: [PATCH] native_bindir
+
+Some libraries, like QT, have pre-processors that convert their input
+files into something that the cross-compiler can process. We find the
+path of those pre-processors via pkg-config-native instead of
+pkg-config.
+
+This path forces the use of pkg-config-native for host_bins arguments.
+
+There are some discussions upstream to merge this patch, but I presonaly believe
+that is is OE only. https://github.com/mesonbuild/meson/issues/1849#issuecomment-303730323
+
+Upstream-Status: Inappropriate [OE specific]
+Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>
+
+---
+ mesonbuild/dependencies/base.py | 19 +++++++++++--------
+ mesonbuild/dependencies/ui.py   |  6 +++---
+ 2 files changed, 14 insertions(+), 11 deletions(-)
+
+diff --git a/mesonbuild/dependencies/base.py b/mesonbuild/dependencies/base.py
+index 368a4bc..9fc398e 100644
+--- a/mesonbuild/dependencies/base.py
++++ b/mesonbuild/dependencies/base.py
+@@ -183,7 +183,7 @@ class Dependency:
+     def get_exe_args(self, compiler):
+         return []
+ 
+-    def get_pkgconfig_variable(self, variable_name, kwargs):
++    def get_pkgconfig_variable(self, variable_name, kwargs, use_native=False):
+         raise DependencyException('{!r} is not a pkgconfig dependency'.format(self.name))
+ 
+     def get_configtool_variable(self, variable_name):
+@@ -261,7 +261,7 @@ class InternalDependency(Dependency):
+                 setattr(result, k, copy.deepcopy(v, memo))
+         return result
+ 
+-    def get_pkgconfig_variable(self, variable_name, kwargs):
++    def get_pkgconfig_variable(self, variable_name, kwargs, use_native=False):
+         raise DependencyException('Method "get_pkgconfig_variable()" is '
+                                   'invalid for an internal dependency')
+ 
+@@ -634,15 +634,18 @@ class PkgConfigDependency(ExternalDependency):
+         return s.format(self.__class__.__name__, self.name, self.is_found,
+                         self.version_reqs)
+ 
+-    def _call_pkgbin_real(self, args, env):
+-        cmd = self.pkgbin.get_command() + args
++    def _call_pkgbin_real(self, args, env, use_native=False):
++        if use_native:
++            cmd = [self.pkgbin.get_command()[0] + "-native"] + args
++        else:
++            cmd = self.pkgbin.get_command() + args
+         p, out, err = Popen_safe(cmd, env=env)
+         rc, out, err = p.returncode, out.strip(), err.strip()
+         call = ' '.join(cmd)
+         mlog.debug("Called `{}` -> {}\n{}".format(call, rc, out))
+         return rc, out, err
+ 
+-    def _call_pkgbin(self, args, env=None):
++    def _call_pkgbin(self, args, env=None, use_native=False):
+         # Always copy the environment since we're going to modify it
+         # with pkg-config variables
+         if env is None:
+@@ -668,7 +671,7 @@ class PkgConfigDependency(ExternalDependency):
+         targs = tuple(args)
+         cache = PkgConfigDependency.pkgbin_cache
+         if (self.pkgbin, targs, fenv) not in cache:
+-            cache[(self.pkgbin, targs, fenv)] = self._call_pkgbin_real(args, env)
++            cache[(self.pkgbin, targs, fenv)] = self._call_pkgbin_real(args, env, use_native)
+         return cache[(self.pkgbin, targs, fenv)]
+ 
+     def _convert_mingw_paths(self, args: T.List[str]) -> T.List[str]:
+@@ -877,7 +880,7 @@ class PkgConfigDependency(ExternalDependency):
+                                       (self.name, out_raw))
+         self.link_args, self.raw_link_args = self._search_libs(out, out_raw)
+ 
+-    def get_pkgconfig_variable(self, variable_name, kwargs):
++    def get_pkgconfig_variable(self, variable_name, kwargs, use_native=False):
+         options = ['--variable=' + variable_name, self.name]
+ 
+         if 'define_variable' in kwargs:
+@@ -890,7 +893,7 @@ class PkgConfigDependency(ExternalDependency):
+ 
+             options = ['--define-variable=' + '='.join(definition)] + options
+ 
+-        ret, out, err = self._call_pkgbin(options)
++        ret, out, err = self._call_pkgbin(options, use_native=use_native)
+         variable = ''
+         if ret != 0:
+             if self.required:
+diff --git a/mesonbuild/dependencies/ui.py b/mesonbuild/dependencies/ui.py
+index 95dfe2b..5f82890 100644
+--- a/mesonbuild/dependencies/ui.py
++++ b/mesonbuild/dependencies/ui.py
+@@ -325,7 +325,7 @@ class QtBaseDependency(ExternalDependency):
+         self.bindir = self.get_pkgconfig_host_bins(core)
+         if not self.bindir:
+             # If exec_prefix is not defined, the pkg-config file is broken
+-            prefix = core.get_pkgconfig_variable('exec_prefix', {})
++            prefix = core.get_pkgconfig_variable('exec_prefix', {}, use_native=True)
+             if prefix:
+                 self.bindir = os.path.join(prefix, 'bin')
+ 
+@@ -528,7 +528,7 @@ class Qt4Dependency(QtBaseDependency):
+         applications = ['moc', 'uic', 'rcc', 'lupdate', 'lrelease']
+         for application in applications:
+             try:
+-                return os.path.dirname(core.get_pkgconfig_variable('%s_location' % application, {}))
++                return os.path.dirname(core.get_pkgconfig_variable('%s_location' % application, {}, use_native=True))
+             except MesonException:
+                 pass
+ 
+@@ -538,7 +538,7 @@ class Qt5Dependency(QtBaseDependency):
+         QtBaseDependency.__init__(self, 'qt5', env, kwargs)
+ 
+     def get_pkgconfig_host_bins(self, core):
+-        return core.get_pkgconfig_variable('host_bins', {})
++        return core.get_pkgconfig_variable('host_bins', {}, use_native=True)
+ 
+     def get_private_includes(self, mod_inc_dir, module):
+         return _qt_get_private_includes(mod_inc_dir, module, self.version)

--- a/recipes-devtools/meson/meson/cross-prop-default.patch
+++ b/recipes-devtools/meson/meson/cross-prop-default.patch
@@ -1,0 +1,23 @@
+meson.build files that use cc.run() in native builds can silently fallback to
+meson.get_cross_property() in cross builds without an exe-wrapper, but there's
+no way to know that this is happening.
+
+As the defaults may be pessimistic (for example, disabling the support for a
+feature that should be enabled) emit a warning when the default is used, so that
+the recipe can explicitly set the cross property as relevant.
+
+Upstream-Status: Submitted [https://github.com/mesonbuild/meson/pull/5071]
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+diff --git a/mesonbuild/interpreter.py b/mesonbuild/interpreter.py
+index 3c3cfae0..10e741ae 100644
+--- a/mesonbuild/interpreter.py
++++ b/mesonbuild/interpreter.py
+@@ -1890,6 +1890,7 @@ class MesonMain(InterpreterObject):
+             return props[propname]
+         except Exception:
+             if len(args) == 2:
++                mlog.warning('Cross property %s is using default value %s' % (propname, args[1]))
+                 return args[1]
+             raise InterpreterException('Unknown cross property: %s.' % propname)
+ 

--- a/recipes-devtools/meson/meson/disable-rpath-handling.patch
+++ b/recipes-devtools/meson/meson/disable-rpath-handling.patch
@@ -1,0 +1,35 @@
+From 9e3fcf192c1ca068d310c648c311f9d850214421 Mon Sep 17 00:00:00 2001
+From: Richard Purdie <richard.purdie@linuxfoundation.org>
+Date: Fri, 23 Nov 2018 15:28:28 +0000
+Subject: [PATCH] meson: Disable rpath stripping at install time
+
+We need to allow our rpaths generated through the compiler flags to make it into
+our binaries. Therefore disable the meson manipulations of these unless there
+is a specific directive to do something differently in the project.
+
+RP 2018/11/23
+
+Upstream-Status: Submitted [https://github.com/mesonbuild/meson/issues/2567]
+
+---
+ mesonbuild/minstall.py | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/mesonbuild/minstall.py b/mesonbuild/minstall.py
+index 0be01fe..5406cab 100644
+--- a/mesonbuild/minstall.py
++++ b/mesonbuild/minstall.py
+@@ -512,8 +512,11 @@ class Installer:
+             if file_copied:
+                 self.did_install_something = True
+                 try:
+-                    depfixer.fix_rpath(outname, t.rpath_dirs_to_remove, install_rpath, final_path,
+-                                       install_name_mappings, verbose=False)
++                    if install_rpath:
++                        depfixer.fix_rpath(outname, t.rpath_dirs_to_remove, install_rpath, final_path,
++                                           install_name_mappings, verbose=False)
++                    else:
++                        print("RPATH changes at install time disabled")
+                 except SystemExit as e:
+                     if isinstance(e.code, int) and e.code == 0:
+                         pass

--- a/recipes-devtools/meson/meson/meson-setup.py
+++ b/recipes-devtools/meson/meson/meson-setup.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import os
+import string
+import sys
+
+class Template(string.Template):
+    delimiter = "@"
+
+class Environ():
+    def __getitem__(self, name):
+        val = os.environ[name]
+        val = ["'%s'" % x for x in val.split()]
+        val = ', '.join(val)
+        val = '[%s]' % val
+        return val
+
+try:
+    sysroot = os.environ['OECORE_NATIVE_SYSROOT']
+except KeyError:
+    print("Not in environment setup, bailing")
+    sys.exit(1)
+
+template_file = os.path.join(sysroot, 'usr/share/meson/meson.cross.template')
+cross_file = os.path.join(sysroot, 'usr/share/meson/%smeson.cross' % os.environ["TARGET_PREFIX"])
+
+with open(template_file) as in_file:
+    template = in_file.read()
+    output = Template(template).substitute(Environ())
+    with open(cross_file, "w") as out_file:
+        out_file.write(output)

--- a/recipes-devtools/meson/meson/meson-wrapper
+++ b/recipes-devtools/meson/meson/meson-wrapper
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ -z "$OECORE_NATIVE_SYSROOT" ]; then
+    echo "OECORE_NATIVE_SYSROOT not set; are you in a Yocto SDK environment?" >&2
+fi
+
+# If these are set to a cross-compile path, meson will get confused and try to
+# use them as native tools. Unset them to prevent this, as all the cross-compile
+# config is already in meson.cross.
+unset CC CXX CPP LD AR NM STRIP
+
+exec "$OECORE_NATIVE_SYSROOT/usr/bin/meson.real" \
+     --cross-file "${OECORE_NATIVE_SYSROOT}/usr/share/meson/${TARGET_PREFIX}meson.cross" \
+     "$@"

--- a/recipes-devtools/meson/meson_0.55.3.bb
+++ b/recipes-devtools/meson/meson_0.55.3.bb
@@ -1,0 +1,36 @@
+HOMEPAGE = "http://mesonbuild.com"
+SUMMARY = "A high performance build system"
+DESCRIPTION = "Meson is a build system designed to increase programmer \
+productivity. It does this by providing a fast, simple and easy to use \
+interface for modern software development tools and practices."
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+SRC_URI = "https://github.com/mesonbuild/meson/releases/download/${PV}/meson-${PV}.tar.gz \
+           file://0001-gtkdoc-fix-issues-that-arise-when-cross-compiling.patch \
+           file://0003-native_bindir.patch \
+           file://0001-python-module-do-not-manipulate-the-environment-when.patch \
+           file://disable-rpath-handling.patch \
+           file://cross-prop-default.patch \
+           file://0001-modules-python.py-do-not-substitute-python-s-install.patch \
+           file://0001-gnome.py-prefix-g-i-paths-with-PKG_CONFIG_SYSROOT_DI.patch \
+           "
+SRC_URI[sha256sum] = "6bed2a25a128bbabe97cf40f63165ebe800e4fcb46db8ab7ef5c2b5789f092a5"
+SRC_URI[md5sum] ="99777acd77838c8669e1421fda8e31c5"
+
+SRC_URI_append_class-native = " \
+    file://0001-Make-CPU-family-warnings-fatal.patch \
+    file://0002-Support-building-allarch-recipes-again.patch \
+"
+
+UPSTREAM_CHECK_URI = "https://github.com/mesonbuild/meson/releases"
+UPSTREAM_CHECK_REGEX = "meson-(?P<pver>\d+(\.\d+)+)\.tar"
+
+inherit setuptools3
+
+RDEPENDS_${PN} = "ninja python3-modules python3-pkg-resources"
+
+FILES_${PN} += "${datadir}/polkit-1"
+
+BBCLASSEXTEND = "native"

--- a/recipes-gnome/gdk-pixbuf/gdk-pixbuf/0001-Add-use_prebuilt_tools-option.patch
+++ b/recipes-gnome/gdk-pixbuf/gdk-pixbuf/0001-Add-use_prebuilt_tools-option.patch
@@ -1,0 +1,173 @@
+From f81b60ebcbbfd9548c8aa1e388662c429068d1e3 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Sat, 8 May 2021 21:58:54 +0200
+Subject: [PATCH] Add use_prebuilt_tools option
+
+This allows using the gdk-pixbuf tools from the host to
+build and install tests in a cross-compile scenarion.
+
+Upstream-Status: Submitted [https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/merge_requests/119]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+
+---
+ gdk-pixbuf/meson.build  | 11 +++++++++--
+ meson.build             |  6 +++---
+ meson_options.txt       |  4 ++++
+ tests/meson.build       | 16 ++++++++--------
+ thumbnailer/meson.build | 24 ++++++++++++++++++------
+ 5 files changed, 42 insertions(+), 19 deletions(-)
+
+diff --git a/gdk-pixbuf/meson.build b/gdk-pixbuf/meson.build
+index 54ff9dd..2e321cf 100644
+--- a/gdk-pixbuf/meson.build
++++ b/gdk-pixbuf/meson.build
+@@ -342,13 +342,20 @@ foreach bin: gdkpixbuf_bin
+                    include_directories: [ root_inc, gdk_pixbuf_inc ],
+                    c_args: common_cflags + gdk_pixbuf_cflags,
+                    install: true)
+-  meson.override_find_program(bin_name, bin)
++  if not get_option('use_prebuilt_tools')
++      meson.override_find_program(bin_name, bin)
++  endif
+ 
+   # Used in tests
+   set_variable(bin_name.underscorify(), bin)
+ endforeach
+ 
+-if not meson.is_cross_build()
++if get_option('use_prebuilt_tools')
++    gdk_pixbuf_query_loaders = find_program('gdk-pixbuf-query-loaders', required: true)
++    gdk_pixbuf_pixdata = find_program('gdk-pixbuf-pixdata', required: true)
++endif
++
++if not meson.is_cross_build() or get_option('use_prebuilt_tools')
+   # The 'loaders.cache' used for testing, so we don't accidentally
+   # load the installed cache; we always build it by default
+   loaders_cache = custom_target('loaders.cache',
+diff --git a/meson.build b/meson.build
+index 813bd43..a93e6f7 100644
+--- a/meson.build
++++ b/meson.build
+@@ -369,18 +369,18 @@ subdir('gdk-pixbuf')
+ # i18n
+ subdir('po')
+ 
+-if not meson.is_cross_build()
++if not meson.is_cross_build() or get_option('use_prebuilt_tools')
+   if get_option('tests')
+     subdir('tests')
+   endif
+-  subdir('thumbnailer')
+ endif
++subdir('thumbnailer')
+ 
+ # Documentation
+ build_docs = get_option('gtk_doc') or get_option('docs')
+ subdir('docs')
+ 
+-if not meson.is_cross_build()
++if not meson.is_cross_build() or get_option('use_prebuilt_tools')
+   meson.add_install_script('build-aux/post-install.py',
+     gdk_pixbuf_bindir,
+     gdk_pixbuf_libdir,
+diff --git a/meson_options.txt b/meson_options.txt
+index d198d99..1c899e9 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -53,4 +53,8 @@ option('gio_sniffing',
+        description: 'Perform file type detection using GIO (Unused on MacOS and Windows)',
+        type: 'boolean',
+        value: true)
++option('use_prebuilt_tools',
++       description: 'Use prebuilt gdk-pixbuf tools from the host for cross-compilation',
++       type: 'boolean',
++       value: false)
+ 
+diff --git a/tests/meson.build b/tests/meson.build
+index 28c2525..d97c02d 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -5,6 +5,12 @@
+ # $PATH. Ideally we should use gnome.compile_resources() and let Meson deal with
+ # this problem: See https://github.com/mesonbuild/meson/issues/8266.
+ if enabled_loaders.contains('png') and host_system != 'windows'
++
++  resources_deps = [loaders_cache,]
++  if not get_option('use_prebuilt_tools')
++    resources_deps += [gdk_pixbuf_pixdata,]
++  endif
++
+   # Resources; we cannot use gnome.compile_resources() here, because we need to
+   # override the environment in order to use the utilities we just built instead
+   # of the system ones
+@@ -21,10 +27,7 @@ if enabled_loaders.contains('png') and host_system != 'windows'
+       '@INPUT@',
+       '@OUTPUT@',
+     ],
+-    depends: [
+-      gdk_pixbuf_pixdata,
+-      loaders_cache,
+-    ],
++    depends: resources_deps,
+   )
+ 
+   resources_h = custom_target('resources.h',
+@@ -40,10 +43,7 @@ if enabled_loaders.contains('png') and host_system != 'windows'
+       '@INPUT@',
+       '@OUTPUT@',
+     ],
+-    depends: [
+-      gdk_pixbuf_pixdata,
+-      loaders_cache,
+-    ],
++    depends: resources_deps,
+   )
+   no_resources = false
+ else
+diff --git a/thumbnailer/meson.build b/thumbnailer/meson.build
+index b6a206d..9336c21 100644
+--- a/thumbnailer/meson.build
++++ b/thumbnailer/meson.build
+@@ -6,13 +6,29 @@ bin = executable('gdk-pixbuf-thumbnailer',
+            ],
+            dependencies: gdk_pixbuf_deps + [ gdkpixbuf_dep ],
+            install: true)
+-meson.override_find_program('gdk-pixbuf-thumbnailer', bin)
++if not get_option('use_prebuilt_tools')
++    meson.override_find_program('gdk-pixbuf-thumbnailer', bin)
++endif
+ 
+ gdk_pixbuf_print_mime_types = executable('gdk-pixbuf-print-mime-types',
+                                          'gdk-pixbuf-print-mime-types.c',
++                                         install: true,
+                                          c_args: common_cflags,
+                                          dependencies: gdk_pixbuf_deps + [ gdkpixbuf_dep ])
+ 
++if get_option('use_prebuilt_tools')
++    gdk_pixbuf_print_mime_types = find_program('gdk-pixbuf-print-mime-types', required: true)
++endif
++
++thumbnailer_deps = [loaders_cache,]
++
++if not get_option('use_prebuilt_tools')
++    thumbnailer_deps += [
++        gdk_pixbuf_print_mime_types,
++        gdk_pixbuf_pixdata,
++    ]
++endif
++
+ custom_target('thumbnailer',
+               input: 'gdk-pixbuf-thumbnailer.thumbnailer.in',
+               output: 'gdk-pixbuf-thumbnailer.thumbnailer',
+@@ -25,10 +41,6 @@ custom_target('thumbnailer',
+                 '@INPUT@',
+                 '@OUTPUT@',
+               ],
+-              depends: [
+-                gdk_pixbuf_print_mime_types,
+-                gdk_pixbuf_pixdata,
+-                loaders_cache,
+-              ],
++              depends: thumbnailer_deps,
+               install: true,
+               install_dir: join_paths(gdk_pixbuf_datadir, 'thumbnailers'))

--- a/recipes-gnome/gdk-pixbuf/gdk-pixbuf/fatal-loader.patch
+++ b/recipes-gnome/gdk-pixbuf/gdk-pixbuf/fatal-loader.patch
@@ -1,0 +1,89 @@
+From b511bd1efb43ffc49c753e309717a242ec686ef1 Mon Sep 17 00:00:00 2001
+From: Ross Burton <ross.burton@intel.com>
+Date: Tue, 1 Apr 2014 17:23:36 +0100
+Subject: [PATCH] gdk-pixbuf: add an option so that loader errors are fatal
+
+If an environment variable is specified set the return value from main() to
+non-zero if the loader had errors (missing libraries, generally).
+
+Upstream-Status: Submitted [https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/merge_requests/144]
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+---
+ gdk-pixbuf/queryloaders.c | 19 +++++++++++++++----
+ 1 file changed, 15 insertions(+), 4 deletions(-)
+
+diff --git a/gdk-pixbuf/queryloaders.c b/gdk-pixbuf/queryloaders.c
+index 1d39b44..2b00815 100644
+--- a/gdk-pixbuf/queryloaders.c
++++ b/gdk-pixbuf/queryloaders.c
+@@ -216,7 +216,7 @@ write_loader_info (GString *contents, const char *path, GdkPixbufFormat *info)
+         g_string_append_c (contents, '\n');
+ }
+ 
+-static void
++static gboolean
+ query_module (GString *contents, const char *dir, const char *file)
+ {
+         char *path;
+@@ -225,6 +225,7 @@ query_module (GString *contents, const char *dir, const char *file)
+         void                    (*fill_vtable)   (GdkPixbufModule *module);
+         gpointer fill_info_ptr;
+         gpointer fill_vtable_ptr;
++        gboolean ret = TRUE;
+ 
+         if (g_path_is_absolute (file))
+                 path = g_strdup (file);
+@@ -274,10 +275,13 @@ query_module (GString *contents, const char *dir, const char *file)
+                                    g_module_error());
+                 else
+                         g_fprintf (stderr, "Cannot load loader %s\n", path);
++                ret = FALSE;
+         }
+         if (module)
+                 g_module_close (module);
+         g_free (path);
++
++        return ret;
+ }
+ 
+ #if defined(G_OS_WIN32) && defined(GDK_PIXBUF_RELOCATABLE)
+@@ -318,6 +322,7 @@ int main (int argc, char **argv)
+         gint first_file = 1;
+         GFile *pixbuf_libdir_file;
+         gchar *pixbuf_libdir;
++        gboolean success = TRUE;
+ 
+ #ifdef G_OS_WIN32
+         gchar *libdir;
+@@ -456,7 +461,9 @@ int main (int argc, char **argv)
+                 }
+                 modules = g_list_sort (modules, (GCompareFunc)strcmp);
+                 for (l = modules; l != NULL; l = l->next)
+-                        query_module (contents, moduledir, l->data);
++                        if (!query_module (contents, moduledir, l->data))
++                                success = FALSE;
++
+                 g_list_free_full (modules, g_free);
+                 g_free (moduledir);
+ #else
+@@ -472,7 +479,8 @@ int main (int argc, char **argv)
+                         infilename = g_locale_to_utf8 (infilename,
+                                                        -1, NULL, NULL, NULL);
+ #endif
+-                        query_module (contents, cwd, infilename);
++                        if (!query_module (contents, cwd, infilename))
++                                success = FALSE;
+                 }
+                 g_free (cwd);
+         }
+@@ -490,5 +498,8 @@ int main (int argc, char **argv)
+ 
+         g_free (pixbuf_libdir);
+ 
+-        return 0;
++        if (g_getenv ("GDK_PIXBUF_FATAL_LOADER"))
++                return success ? 0 : 1;
++        else
++                return 0;
+ }

--- a/recipes-gnome/gdk-pixbuf/gdk-pixbuf/run-ptest
+++ b/recipes-gnome/gdk-pixbuf/gdk-pixbuf/run-ptest
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+gnome-desktop-testing-runner gdk-pixbuf

--- a/recipes-gnome/gdk-pixbuf/gdk-pixbuf_2.42.9.bb
+++ b/recipes-gnome/gdk-pixbuf/gdk-pixbuf_2.42.9.bb
@@ -1,0 +1,131 @@
+SUMMARY = "Image loading library for GTK+"
+DESCRIPTION = "The GDK Pixbuf library provides: Image loading and saving \
+facilities, fast scaling and compositing of pixbufs and Simple animation \
+loading (ie. animated GIFs)"
+HOMEPAGE = "https://wiki.gnome.org/Projects/GdkPixbuf"
+BUGTRACKER = "https://gitlab.gnome.org/GNOME/gdk-pixbuf/issues"
+
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
+                    file://gdk-pixbuf/gdk-pixbuf.h;endline=26;md5=72b39da7cbdde2e665329fef618e1d6b \
+                    "
+
+SECTION = "libs"
+
+DEPENDS = "glib-2.0 gdk-pixbuf-native shared-mime-info"
+DEPENDS_remove_class-native = "gdk-pixbuf-native"
+
+MAJ_VER = "${@oe.utils.trim_version("${PV}", 2)}"
+
+SRC_URI = "${GNOME_MIRROR}/${BPN}/${MAJ_VER}/${BPN}-${PV}.tar.xz \
+           file://run-ptest \
+           file://fatal-loader.patch \
+           file://0001-Add-use_prebuilt_tools-option.patch \
+           "
+
+SRC_URI[sha256sum] = "28f7958e7bf29a32d4e963556d241d0a41a6786582ff6a5ad11665e0347fc962"
+inherit meson pkgconfig gettext pixbufcache ptest-gnome upstream-version-is-even gobject-introspection lib_package
+
+GIR_MESON_OPTION = 'introspection'
+GIR_MESON_ENABLE_FLAG = "enabled"
+GIR_MESON_DISABLE_FLAG = "disabled"
+
+LIBV = "2.10.0"
+
+GDK_PIXBUF_LOADERS ?= "png jpeg"
+
+PACKAGECONFIG = "${GDK_PIXBUF_LOADERS} \
+                 ${@bb.utils.contains('PTEST_ENABLED', '1', 'tests', '', d)}"
+PACKAGECONFIG_class-native = "${GDK_PIXBUF_LOADERS}"
+
+PACKAGECONFIG[png] =     "-Dpng=enabled,-Dpng=disabled,libpng"
+PACKAGECONFIG[jpeg] = "-Djpeg=enabled,-Djpeg=disabled,jpeg"
+PACKAGECONFIG[tiff] = "-Dtiff=enabled,-Dtiff=disabled,tiff"
+PACKAGECONFIG[tests] = "-Dinstalled_tests=true,-Dinstalled_tests=false"
+
+EXTRA_OEMESON = "-Dman=false"
+
+EXTRA_OEMESON_append_class-target = " \
+    -Duse_prebuilt_tools=true \
+"
+
+EXTRA_OEMESON_append_class-nativesdk = " \
+    -Duse_prebuilt_tools=true \
+"
+
+PACKAGES =+ "${PN}-xlib"
+
+# For GIO image type sniffing
+RDEPENDS_${PN} = "shared-mime-info"
+
+FILES_${PN}-xlib = "${libdir}/*pixbuf_xlib*${SOLIBS}"
+ALLOW_EMPTY_${PN}-xlib = "1"
+
+FILES_${PN} += "${libdir}/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders"
+
+FILES_${PN}-bin += "${datadir}/thumbnailers/gdk-pixbuf-thumbnailer.thumbnailer"
+
+FILES_${PN}-dev += " \
+	${bindir}/gdk-pixbuf-csource \
+	${bindir}/gdk-pixbuf-pixdata \
+        ${bindir}/gdk-pixbuf-print-mime-types \
+	${includedir}/* \
+	${libdir}/gdk-pixbuf-2.0/${LIBV}/loaders/*.la \
+"
+
+PACKAGES_DYNAMIC += "^gdk-pixbuf-loader-.*"
+PACKAGES_DYNAMIC_class-native = ""
+
+python populate_packages_prepend () {
+    postinst_pixbufloader = d.getVar("postinst_pixbufloader")
+
+    loaders_root = d.expand('${libdir}/gdk-pixbuf-2.0/${LIBV}/loaders')
+
+    packages = ' '.join(do_split_packages(d, loaders_root, r'^libpixbufloader-(.*)\.so$', 'gdk-pixbuf-loader-%s', 'GDK pixbuf loader for %s'))
+    d.setVar('PIXBUF_PACKAGES', packages)
+
+    # The test suite exercises all the loaders, so ensure they are all
+    # dependencies of the ptest package.
+    d.appendVar("RDEPENDS_%s-ptest" % d.getVar('PN'), " " + packages)
+}
+
+do_install_append() {
+	# Copy gdk-pixbuf-query-loaders into libdir so it is always available
+	# in multilib builds.
+	cp ${D}/${bindir}/gdk-pixbuf-query-loaders ${D}/${libdir}/gdk-pixbuf-2.0/
+
+}
+
+do_install_ptest() {
+        # Remove a bad fuzzing attempt that sporadically fails without a way to reproduce
+	rm ${D}/${datadir}/installed-tests/gdk-pixbuf/pixbuf-randomly-modified.test
+        # https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/issues/215
+	rm ${D}/${datadir}/installed-tests/gdk-pixbuf/pixbuf-jpeg.test
+}
+
+do_install_append_class-native() {
+	find ${D}${libdir} -name "libpixbufloader-*.la" -exec rm \{\} \;
+
+	create_wrapper ${D}/${bindir}/gdk-pixbuf-csource \
+		XDG_DATA_DIRS=${STAGING_DATADIR} \
+		GDK_PIXBUF_MODULE_FILE=${STAGING_LIBDIR_NATIVE}/gdk-pixbuf-2.0/${LIBV}/loaders.cache
+
+	create_wrapper ${D}/${bindir}/gdk-pixbuf-pixdata \
+		XDG_DATA_DIRS=${STAGING_DATADIR} \
+		GDK_PIXBUF_MODULE_FILE=${STAGING_LIBDIR_NATIVE}/gdk-pixbuf-2.0/${LIBV}/loaders.cache
+
+	create_wrapper ${D}/${bindir}/gdk-pixbuf-print-mime-types \
+		XDG_DATA_DIRS=${STAGING_DATADIR} \
+		GDK_PIXBUF_MODULE_FILE=${STAGING_LIBDIR_NATIVE}/gdk-pixbuf-2.0/${LIBV}/loaders.cache
+
+	create_wrapper ${D}/${libdir}/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders \
+		XDG_DATA_DIRS=${STAGING_DATADIR} \
+		GDK_PIXBUF_MODULE_FILE=${STAGING_LIBDIR_NATIVE}/gdk-pixbuf-2.0/${LIBV}/loaders.cache \
+		GDK_PIXBUF_MODULEDIR=${STAGING_LIBDIR_NATIVE}/gdk-pixbuf-2.0/${LIBV}/loaders
+
+	create_wrapper ${D}/${bindir}/gdk-pixbuf-query-loaders \
+		XDG_DATA_DIRS=${STAGING_DATADIR} \
+		GDK_PIXBUF_MODULE_FILE=${STAGING_LIBDIR_NATIVE}/gdk-pixbuf-2.0/${LIBV}/loaders.cache \
+		GDK_PIXBUF_MODULEDIR=${STAGING_LIBDIR_NATIVE}/gdk-pixbuf-2.0/${LIBV}/loaders
+}
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This version of gdk-pixbuf is probably required for more recent electron to run.

Closes RCORE-235