### PR TITLE
opentrons-robot-server: module udev rules

### DIFF
--- a/recipes-robot/opentrons-robot-server/files/95-opentrons-modules.rules
+++ b/recipes-robot/opentrons-robot-server/files/95-opentrons-modules.rules
@@ -1,0 +1,13 @@
+# legacy modules, generally not compatible with ot3
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee93", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_tempdeck%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee90", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_magdeck%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee5a", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_avrdude_bootloader%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed8c", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_thermocycler%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed12", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_samba_bootloader%n"
+# adafruit feather m0 board for dev:
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="800b", ATTRS{idVendor}=="239a", SYMLINK+="ot_module_thermocycler%n"
+
+# these boards are compatible with ot3
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="4853", ATTRS{idVendor}=="0483", SYMLINK+="ot_module_heatershaker%n"
+# gen2 thermocycler on stm32:
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed8d", ATTRS{idVendor}=="0483", SYMLINK+="ot_module_thermocycler%n"

--- a/recipes-robot/opentrons-robot-server/opentrons-robot-server_git.bb
+++ b/recipes-robot/opentrons-robot-server/opentrons-robot-server_git.bb
@@ -44,10 +44,15 @@ do_install_append () {
     install -d ${D}${systemd_system_unitdir}/opentrons-robot-server.service.d
     install -m 0644 ${B}/robot-server-version.conf ${D}${systemd_system_unitdir}/opentrons-robot-server.service.d/robot-server-version.conf
     install -m 0644 ${WORKDIR}/opentrons-ot3-canbus.service ${D}${systemd_system_unitdir}/opentrons-ot3-canbus.service
+    install -d ${D}${sysconfdir}/udev/rules.d/
+    install -d ${WORKDIR}/95-opentrons-modules.rules ${D}${sysconfdir}/udev/rules.d/95-opentrons-modules.rules
 }
 
-FILES_${PN}_append = " ${systemd_system_unitdir/opentrons-robot-server.service.d ${systemd_system_unitdir}/opentrons-robot-server.service.d/robot-server-version.conf"
+FILES_${PN}_append = " ${systemd_system_unitdir/opentrons-robot-server.service.d \
+                       ${systemd_system_unitdir}/opentrons-robot-server.service.d/robot-server-version.conf \
+                       ${sysconfdir}/udev/rules.d/95-opentrons-modules.rules \
+                       "
 
-RDEPENDS_${PN} += " python3-numpy python3-systemd nginx python-can python3-pyzmq libgpiod-python"
+RDEPENDS_${PN} += " udev python3-numpy python3-systemd nginx python-can python3-pyzmq libgpiod-python"
 
 inherit pipenv_app_bundle


### PR DESCRIPTION
These are needed to create the special symlinks for the opentrons module usb serials.