### PR TITLE
recipes-robot: add module connection and communicatin

### DIFF
--- a/.github/workflows/enable-upstream-builds.yaml
+++ b/.github/workflows/enable-upstream-builds.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   branch-and-build:
     name: 'Ensure a matching branch exists in oe-core then build'
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-latest'
     steps:
       - name: 'Format head ref properly'
         run: |

--- a/.github/workflows/mainline-builds.yml
+++ b/.github/workflows/mainline-builds.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: 'Start an upstream build'
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-latest'
     steps:
       - name: 'Start build'
         env:

--- a/.github/workflows/remove-upstream-branch.yaml
+++ b/.github/workflows/remove-upstream-branch.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   remove-branch:
     name: 'Remove an automatically-created branch (as long as it has no changes)'
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-latest'
     steps:
       - name: 'Format head ref properly'
         run: |

--- a/recipes-robot/opentrons-robot-server/files/95-opentrons-modules.rules
+++ b/recipes-robot/opentrons-robot-server/files/95-opentrons-modules.rules
@@ -1,0 +1,13 @@
+# legacy modules, generally not compatible with ot3
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee93", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_tempdeck%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee90", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_magdeck%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee5a", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_avrdude_bootloader%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed8c", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_thermocycler%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed12", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_samba_bootloader%n"
+# adafruit feather m0 board for dev:
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="800b", ATTRS{idVendor}=="239a", SYMLINK+="ot_module_thermocycler%n"
+
+# these boards are compatible with ot3
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="4853", ATTRS{idVendor}=="0483", SYMLINK+="ot_module_heatershaker%n"
+# gen2 thermocycler on stm32:
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed8d", ATTRS{idVendor}=="0483", SYMLINK+="ot_module_thermocycler%n"

--- a/recipes-robot/opentrons-robot-server/opentrons-robot-server_git.bb
+++ b/recipes-robot/opentrons-robot-server/opentrons-robot-server_git.bb
@@ -21,7 +21,7 @@ inherit insane systemd get_ot_package_version
 SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE_${PN} = "opentrons-robot-server.service opentrons-ot3-canbus.service"
 FILESEXTRAPATHS_prepend = "${THISDIR}/files:"
-SRC_URI_append = " file://opentrons-robot-server.service file://opentrons-ot3-canbus.service"
+SRC_URI_append = " file://opentrons-robot-server.service file://opentrons-ot3-canbus.service file://95-opentrons-modules.rules"
 
 PIPENV_APP_BUNDLE_PROJECT_ROOT = "${S}/robot-server"
 PIPENV_APP_BUNDLE_DIR = "/opt/opentrons-robot-server"
@@ -44,10 +44,15 @@ do_install_append () {
     install -d ${D}${systemd_system_unitdir}/opentrons-robot-server.service.d
     install -m 0644 ${B}/robot-server-version.conf ${D}${systemd_system_unitdir}/opentrons-robot-server.service.d/robot-server-version.conf
     install -m 0644 ${WORKDIR}/opentrons-ot3-canbus.service ${D}${systemd_system_unitdir}/opentrons-ot3-canbus.service
+    install -d ${D}${sysconfdir}/udev/rules.d/
+    install -m 0644 ${WORKDIR}/95-opentrons-modules.rules ${D}${sysconfdir}/udev/rules.d/95-opentrons-modules.rules
 }
 
-FILES_${PN}_append = " ${systemd_system_unitdir/opentrons-robot-server.service.d ${systemd_system_unitdir}/opentrons-robot-server.service.d/robot-server-version.conf"
+FILES_${PN}_append = " ${systemd_system_unitdir/opentrons-robot-server.service.d \
+                       ${systemd_system_unitdir}/opentrons-robot-server.service.d/robot-server-version.conf \
+                       ${sysconfdir}/udev/rules.d/95-opentrons-modules.rules \
+                       "
 
-RDEPENDS_${PN} += " python3-numpy python3-systemd nginx python-can python3-pyzmq libgpiod-python"
+RDEPENDS_${PN} += " udev python3-numpy python3-systemd nginx python-can python3-pyzmq libgpiod-python"
 
 inherit pipenv_app_bundle

--- a/recipes-robot/opentrons-robot-server/opentrons-robot-server_git.bb
+++ b/recipes-robot/opentrons-robot-server/opentrons-robot-server_git.bb
@@ -53,6 +53,6 @@ FILES_${PN}_append = " ${systemd_system_unitdir/opentrons-robot-server.service.d
                        ${sysconfdir}/udev/rules.d/95-opentrons-modules.rules \
                        "
 
-RDEPENDS_${PN} += " udev python3-numpy python3-systemd nginx python-can python3-pyzmq libgpiod-python"
+RDEPENDS_${PN} += " udev python3-numpy python3-systemd nginx python-can python3-pyzmq libgpiod-python python-aionotify"
 
 inherit pipenv_app_bundle

--- a/recipes-robot/python-aionotify/python-aionotify_0.2.0.bb
+++ b/recipes-robot/python-aionotify/python-aionotify_0.2.0.bb
@@ -1,0 +1,11 @@
+SUMMARY = "Simple, asyncio-based inotify library for Python."
+HOMEPAGE = "https://github.com/rbarrois/aionotify"
+LICENSE = "BSD"
+
+LIC_FILES_CHECKSUM = "file://LICENSE;md5=95348062da1183a702f2bfba094b9952"
+SRC_URI = "https://files.pythonhosted.org/packages/57/c0/237d434870a024a16d89751ec9f4e5340a6d84d49ccb1ab738b3fdee907a/aionotify-${PV}.tar.gz"
+SRC_URI[md5sum] = "252066f7ab85aa71a89d23d3e42ce041"
+SRC_URL[sha256sum] = "64b702ad0eb115034533f9f62730a9253b79f5ff0fbf3d100c392124cdf12507"
+
+inherit setuptools3
+

--- a/recipes-robot/python-aionotify/python-aionotify_0.2.0.bb
+++ b/recipes-robot/python-aionotify/python-aionotify_0.2.0.bb
@@ -2,10 +2,11 @@ SUMMARY = "Simple, asyncio-based inotify library for Python."
 HOMEPAGE = "https://github.com/rbarrois/aionotify"
 LICENSE = "BSD"
 
-LIC_FILES_CHECKSUM = "file://LICENSE;md5=95348062da1183a702f2bfba094b9952"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=95348062da1183a702f2bfba094b9952"
 SRC_URI = "https://files.pythonhosted.org/packages/57/c0/237d434870a024a16d89751ec9f4e5340a6d84d49ccb1ab738b3fdee907a/aionotify-${PV}.tar.gz"
 SRC_URI[md5sum] = "252066f7ab85aa71a89d23d3e42ce041"
 SRC_URL[sha256sum] = "64b702ad0eb115034533f9f62730a9253b79f5ff0fbf3d100c392124cdf12507"
+S = "${WORKDIR}/aionotify-${PV}"
 
 inherit setuptools3
 


### PR DESCRIPTION
We use ainotify to wrap inotify watch fds in python asyncio interfaces to detect modules. Add it and set it as an rdepend of robot server.

We'll also need udev rules to properly make symlinks for the module serial links.